### PR TITLE
Add Marble texture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,13 +104,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -167,6 +178,17 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "noise"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba869e17168793186c10ca82c7079a4ffdeac4f1a7d9e755b9491c028180e40"
+dependencies = [
+ "num-traits",
+ "rand 0.7.3",
+ "rand_xorshift",
+]
 
 [[package]]
 name = "num-traits"
@@ -230,7 +252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -305,13 +327,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -321,7 +366,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -330,7 +384,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -359,8 +431,9 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "glam",
+ "noise",
  "palette",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -415,6 +488,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.0.29", features = ["derive", "cargo"] }
 glam = "0.22.0"
+noise = "0.8.2"
 palette = "0.6.1"
 rand = "0.8.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use clap::{Parser, ValueEnum};
 use glam::{dvec3, DVec3};
 
 use rand::random;
+use shimmer::textures::marble::Marble;
 use std::rc::Rc;
 use std::time::Instant;
 
@@ -25,6 +26,7 @@ enum Scene {
     RandomSpheres,
     RandomMovingSpheres,
     TwoSpheres,
+    Marble,
 }
 
 #[derive(Parser)]
@@ -114,6 +116,7 @@ fn main() {
         Scene::RandomSpheres => random_spheres(),
         Scene::RandomMovingSpheres => random_moving_spheres(),
         Scene::TwoSpheres => two_spheres(),
+        Scene::Marble => two_marble_spheres(),
     };
 
     let samples_per_pixel = cli.samples_per_pixel;
@@ -282,5 +285,22 @@ fn two_spheres() -> HittableList {
         checkerboard.clone(),
     )));
 
+    world
+}
+
+fn two_marble_spheres() -> HittableList {
+    let mut world = HittableList::new();
+
+    let marble_texture = Rc::new(Marble::new(4.0));
+    world.add(Rc::new(Sphere::new(
+        dvec3(0.0, -1000.0, 0.0),
+        1000.0,
+        Rc::new(Lambertian::new(marble_texture.clone())),
+    )));
+    world.add(Rc::new(Sphere::new(
+        dvec3(0.0, 2.0, 0.0),
+        2.0,
+        Rc::new(Lambertian::new(marble_texture)),
+    )));
     world
 }

--- a/src/textures/marble.rs
+++ b/src/textures/marble.rs
@@ -1,0 +1,29 @@
+use glam::dvec3;
+use noise::{NoiseFn, Perlin, Turbulence};
+use rand::random;
+
+use super::texture::Texture;
+
+pub struct Marble {
+    noise: Turbulence<Perlin, Perlin>,
+    scale: f64,
+}
+
+impl Marble {
+    pub fn new(scale: f64) -> Marble {
+        let perlin = Perlin::new(random::<u32>());
+        let turb: Turbulence<_, Perlin> = Turbulence::new(perlin)
+            .set_frequency(1.0)
+            .set_power(1.0)
+            .set_roughness(6);
+        Marble { noise: turb, scale }
+    }
+}
+
+impl Texture for Marble {
+    fn value(&self, _u: f64, _v: f64, p: &glam::DVec3) -> glam::DVec3 {
+        dvec3(1.0, 1.0, 1.0)
+            * 0.5
+            * (1.0 + f64::sin(self.scale * p.z + 10.0 * self.noise.get(<[f64; 3]>::from(*p))))
+    }
+}

--- a/src/textures/mod.rs
+++ b/src/textures/mod.rs
@@ -1,3 +1,4 @@
 pub mod checker;
+pub mod marble;
 pub mod solid_color;
 pub mod texture;


### PR DESCRIPTION
![marble](https://user-images.githubusercontent.com/26149045/209050224-bfd6322e-1b4f-48a0-a91c-a96d6ebaaa3f.png)

Rather than adding perlin textures per se, I think that it makes sense to just add a specific Marble texture as an example of a procedural texture that uses perlin noise, turbnulence, etc, with the expectation that users would create similar procedural textures using the noise crate.
