### PR TITLE
38 add tiled rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Shimmer is a CPU-bound ray tracing library.
   * Extensible Texture trait representation.
 * Geometry
   * Motion Blur
-* BVH (Bounding Volume Hierarchy) implementation for fast ray collisions.
+* Performance
+  * BVH (Bounding Volume Hierarchy) implementation for fast ray collisions.
+  * Tiled rendering
 * Camera
   * Depth of Field
   * Shutter Speed

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,12 @@ struct Cli {
     /// Maximum number of bounces for each ray.
     #[arg(short, long, default_value = "50")]
     depth: u32,
+    /// Width of each render tile, in pixels.
+    #[arg(long, default_value = "8")]
+    tile_width: u32,
+    /// Height of each render tile, in pixels.
+    #[arg(long, default_value = "8")]
+    tile_height: u32,
     /// x, y, z
     /// Origin of the camera.
     #[arg(long, num_args = 3, default_values = vec!["13.0", "2.0", "3.0"])]
@@ -122,7 +128,14 @@ fn main() {
     let samples_per_pixel = cli.samples_per_pixel;
     let max_depth = cli.depth;
     renderer
-        .render(&camera, &world, samples_per_pixel, max_depth)
+        .render(
+            &camera,
+            &world,
+            samples_per_pixel,
+            max_depth,
+            cli.tile_width,
+            cli.tile_height,
+        )
         .unwrap();
 
     let duration = start.elapsed();

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ struct Cli {
     scene: Scene,
     /// Image width; image height is determined by this value and the aspect ratio.
     #[arg(short = 'w', long, default_value = "1080")]
-    image_width: u32,
+    image_width: usize,
     #[arg(short, long, num_args = 2, default_values = vec!["16.0", "9.0"])]
     /// Aspect ratio (horizontal, vertical).
     aspect_ratio: Vec<f64>,
@@ -48,10 +48,10 @@ struct Cli {
     depth: u32,
     /// Width of each render tile, in pixels.
     #[arg(long, default_value = "8")]
-    tile_width: u32,
+    tile_width: usize,
     /// Height of each render tile, in pixels.
     #[arg(long, default_value = "8")]
-    tile_height: u32,
+    tile_height: usize,
     /// x, y, z
     /// Origin of the camera.
     #[arg(long, num_args = 3, default_values = vec!["13.0", "2.0", "3.0"])]

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -89,9 +89,4 @@ impl Renderer {
 
         Ok(())
     }
-
-    #[allow(dead_code)]
-    pub fn aspect_ratio(&self) -> f32 {
-        self.image_width as f32 / self.image_height as f32
-    }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -10,23 +10,23 @@ use crate::hittable::HittableList;
 use crate::utils::srgb_from_dvec3;
 
 pub struct Renderer {
-    image_width: u32,
-    image_height: u32,
+    image_width: usize,
+    image_height: usize,
 }
 
 impl Renderer {
     #[allow(dead_code)]
-    pub fn new(image_width: u32, image_height: u32) -> Renderer {
+    pub fn new(image_width: usize, image_height: usize) -> Renderer {
         Renderer {
             image_width,
             image_height,
         }
     }
 
-    pub fn from_aspect_ratio(image_width: u32, aspect_ratio: f64) -> Renderer {
+    pub fn from_aspect_ratio(image_width: usize, aspect_ratio: f64) -> Renderer {
         Renderer {
             image_width,
-            image_height: (image_width as f64 / aspect_ratio) as u32,
+            image_height: (image_width as f64 / aspect_ratio) as usize,
         }
     }
 
@@ -37,8 +37,8 @@ impl Renderer {
         world: &HittableList,
         samples_per_pixel: u32,
         max_depth: u32,
-        tile_width: u32,
-        tile_height: u32,
+        tile_width: usize,
+        tile_height: usize,
     ) -> std::io::Result<()> {
         let stdout = io::stdout();
         let mut buf_writer = io::BufWriter::new(stdout);
@@ -119,13 +119,13 @@ impl Renderer {
 struct ImageColors {
     /// Matrix of colors in the image, flattened row-major.
     colors: Vec<Srgb>,
-    image_width: u32,
+    image_width: usize,
 }
 
 impl ImageColors {
-    pub fn new(image_width: u32, image_height: u32) -> ImageColors {
+    pub fn new(image_width: usize, image_height: usize) -> ImageColors {
         ImageColors {
-            colors: vec![Srgb::new(0.0, 0.0, 0.0); (image_width * image_height) as usize],
+            colors: vec![Srgb::new(0.0, 0.0, 0.0); image_width * image_height],
             image_width,
         }
     }
@@ -135,33 +135,33 @@ impl ImageColors {
         self.colors[idx] = color;
     }
 
-    pub fn get_color(&self, x: u32, y: u32) -> &Srgb {
+    pub fn get_color(&self, x: usize, y: usize) -> &Srgb {
         &self.colors[self.get_idx(x, y)]
     }
 
-    fn get_idx(&self, x: u32, y: u32) -> usize {
-        (y * self.image_width + x) as usize
+    fn get_idx(&self, x: usize, y: usize) -> usize {
+        y * self.image_width + x
     }
 }
 
 struct PixelCoordinates {
-    pub x: u32,
-    pub y: u32,
+    pub x: usize,
+    pub y: usize,
 }
 
 struct Tile {
     /// Width of the tile, in pixels.
-    width: u32,
+    width: usize,
     /// Height of the tile, in pixels.
-    height: u32,
+    height: usize,
     /// The first pixel X coordinate of this tile in the full image.
-    x_coord_start: u32,
+    x_coord_start: usize,
     /// The first pixel Y coordinate of this tile in the full image.
-    y_coord_start: u32,
+    y_coord_start: usize,
 }
 
 impl Tile {
-    pub fn new(width: u32, height: u32, x_coord_start: u32, y_coord_start: u32) -> Tile {
+    pub fn new(width: usize, height: usize, x_coord_start: usize, y_coord_start: usize) -> Tile {
         Tile {
             width,
             height,
@@ -184,10 +184,10 @@ impl Tile {
     /// * `tile_width` - Width of each tile, in pixels.
     /// * `tile_height` - Height of each tile, in pixels.
     pub fn tile(
-        image_width: u32,
-        image_height: u32,
-        tile_width: u32,
-        tile_height: u32,
+        image_width: usize,
+        image_height: usize,
+        tile_width: usize,
+        tile_height: usize,
     ) -> Vec<Tile> {
         let num_horizontal_tiles = image_width / tile_width;
         let remainder_horizontal_pixels = image_width % tile_width;
@@ -245,7 +245,7 @@ impl Tile {
 
     /// Given the `x`, `y` coordinate within this tile, get the corresponding
     /// pixel coordinate in the full image.
-    pub fn get_pixel_coordinates(&self, x: u32, y: u32) -> PixelCoordinates {
+    pub fn get_pixel_coordinates(&self, x: usize, y: usize) -> PixelCoordinates {
         assert!(x < self.width);
         assert!(y < self.height);
         PixelCoordinates {


### PR DESCRIPTION
While I saw no speed-up in my unscientific trials on the random-spheres scene, it's possible that the scene is simple enough that cache efficiency will really not help it compared to a scene with many, many tris.

Regardless, I think we should merge it because it does not hurt the performance from my trials, it matches the suggestion from literature I've linked in the related issues, and because our multi-threading approach will be tile based, so we need this in to get multi-threading, which should get us a speed up regardless of scene complexity.