### PR TITLE
Switch to Rayon for multi-threading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,20 +73,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,16 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +114,12 @@ checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "errno"
@@ -273,6 +255,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -482,6 +474,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,11 +526,11 @@ name = "shimmer"
 version = "0.1.0"
 dependencies = [
  "clap",
- "crossbeam",
  "glam",
  "noise",
  "palette",
  "rand 0.8.5",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.0.29", features = ["derive", "cargo"] }
-crossbeam = "0.8.2"
 glam = "0.22.0"
 noise = "0.8.2"
 palette = "0.6.1"
 rand = "0.8.5"
+rayon = "1.6.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,9 +46,6 @@ struct Cli {
     /// Maximum number of bounces for each ray.
     #[arg(short, long, default_value = "50")]
     depth: u32,
-    /// Number of threads to use during rendering.
-    #[arg(long, default_value = "16")]
-    threads: u32,
     /// Width of each render tile, in pixels.
     #[arg(long, default_value = "8")]
     tile_width: usize,
@@ -136,7 +133,6 @@ fn main() {
             &world,
             samples_per_pixel,
             max_depth,
-            cli.threads,
             cli.tile_width,
             cli.tile_height,
         )

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,13 +1,10 @@
 use std::io;
 use std::io::Write;
-use std::sync::Arc;
 
-use crossbeam::channel;
-use crossbeam::channel::Sender;
-use crossbeam::queue::ArrayQueue;
 use palette::Pixel;
 use palette::Srgb;
 use rand::random;
+use rayon::prelude::*;
 
 use crate::camera::Camera;
 use crate::hittable::HittableList;
@@ -41,7 +38,6 @@ impl Renderer {
         world: &HittableList,
         samples_per_pixel: u32,
         max_depth: u32,
-        threads: u32,
         tile_width: usize,
         tile_height: usize,
     ) -> std::io::Result<()> {
@@ -49,45 +45,38 @@ impl Renderer {
         let mut stderr_buf_writer = io::BufWriter::new(stderr);
 
         let tiles = Tile::tile(self.image_width, self.image_height, tile_width, tile_height);
-        let tiles_queue = Arc::new(ArrayQueue::new(tiles.len()));
-        tiles.into_iter().for_each(|tile| {
-            tiles_queue.push(tile).unwrap();
-        });
         let mut colors = ImageColors::new(self.image_width, self.image_height);
 
-        crossbeam::scope(|scope| {
-            let (s, r) = channel::unbounded();
-            for _i in 0..threads {
-                let s = s.clone();
-                let tiles_queue = tiles_queue.clone();
-                scope.spawn(move |_| {
-                    self.render_tile(s, tiles_queue, samples_per_pixel, world, max_depth, camera);
-                });
-            }
-            drop(s);
-
-            for received in r {
-                let tiles_remaining = tiles_queue.len();
-                write!(
-                    stderr_buf_writer,
-                    "\rTiles remaining: {:07}",
-                    tiles_remaining
-                )
-                .unwrap();
-                stderr_buf_writer.flush().unwrap();
-
-                // Update the image with the colors from this tile
-                let tile = &received.tile;
-                for x in 0..tile.width {
-                    for y in 0..tile.height {
-                        let full_image_pixel_coords = tile.get_full_image_pixel_coordinates(x, y);
-                        let color = received.colors.get_color(x, y);
-                        colors.set_color(&full_image_pixel_coords, *color);
+        let rendered_tiles: Vec<RenderedTile> = tiles
+            .par_iter()
+            .map(|tile| {
+                let mut tile_colors = ImageColors::new(tile.width, tile.height);
+                for y in 0..tile.height {
+                    for x in 0..tile.width {
+                        let pixel_coords = tile.get_full_image_pixel_coordinates(x, y);
+                        let color = self.get_color(
+                            &pixel_coords,
+                            samples_per_pixel,
+                            world,
+                            max_depth,
+                            camera,
+                        );
+                        tile_colors.set_color(&PixelCoordinates::new(x, y), color);
                     }
                 }
+                RenderedTile::new(*tile, tile_colors)
+            })
+            .collect();
+        rendered_tiles.iter().for_each(|rendered_tile| {
+            for x in 0..rendered_tile.tile.width {
+                for y in 0..rendered_tile.tile.height {
+                    let full_image_pixel_coords =
+                        rendered_tile.tile.get_full_image_pixel_coordinates(x, y);
+                    let color = rendered_tile.colors.get_color(x, y);
+                    colors.set_color(&full_image_pixel_coords, *color);
+                }
             }
-        })
-        .unwrap();
+        });
 
         write!(stderr_buf_writer, "\nDone tracing.\n")?;
 
@@ -140,55 +129,20 @@ impl Renderer {
         color_accumulator = color_accumulator / samples_per_pixel as f32;
         Srgb::from_linear(color_accumulator)
     }
-
-    fn render_tile(
-        &self,
-        sender: Sender<TileRenderMessage>,
-        tiles_queue: Arc<ArrayQueue<Tile>>,
-        samples_per_pixel: u32,
-        world: &HittableList,
-        max_depth: u32,
-        camera: &Camera,
-    ) {
-        loop {
-            let tile = tiles_queue.pop();
-            if let Some(tile) = tile {
-                let mut tile_colors = ImageColors::new(tile.width, tile.height);
-                for y in 0..tile.height {
-                    for x in 0..tile.width {
-                        let pixel_coords = tile.get_full_image_pixel_coordinates(x, y);
-                        let color = self.get_color(
-                            &pixel_coords,
-                            samples_per_pixel,
-                            world,
-                            max_depth,
-                            camera,
-                        );
-                        tile_colors.set_color(&PixelCoordinates::new(x, y), color);
-                    }
-                }
-                sender
-                    .send(TileRenderMessage::new(tile, tile_colors))
-                    .unwrap();
-            } else {
-                return;
-            }
-        }
-    }
 }
 
-/// The information necessary to populate ImageColor with color data
-/// for a single Tile's pixels. Sent from worker threads to the main
-/// thread in Renderer.
-struct TileRenderMessage {
+/// Carries this tile's render in `colors`, while `tile` carries
+/// the information needed to update the full image's colors from
+/// this tile.
+struct RenderedTile {
     tile: Tile,
     /// The colors for this tile (where this tile is the "Image")
     colors: ImageColors,
 }
 
-impl TileRenderMessage {
-    pub fn new(tile: Tile, colors: ImageColors) -> TileRenderMessage {
-        TileRenderMessage { tile, colors }
+impl RenderedTile {
+    pub fn new(tile: Tile, colors: ImageColors) -> RenderedTile {
+        RenderedTile { tile, colors }
     }
 }
 


### PR DESCRIPTION
This results in much cleaner code than dealing with messages and channels and thread spawning and so on. It's also likely more efficient, as Rayon can handle thread count intelligently (in any case, I saw no performance degradation).

Resolves #44 .