### PR TITLE
BxDF Interface, Diffuse BxDF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ name = "shimmer"
 version = "0.1.0"
 dependencies = [
  "auto_ops",
+ "bitflags",
  "env_logger",
  "float-cmp",
  "float_next_after",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ itertools = "0.11.0"
 once_cell = "1.18.0"
 rand = "0.8.5"
 rgb2spec = "0.1.1"
+bitflags = "2.4.1"
 
 [dev-dependencies]
 float_next_after = "1.0.0"

--- a/src/bsdf.rs
+++ b/src/bsdf.rs
@@ -1,0 +1,106 @@
+use crate::{
+    bxdf::{BSDFSample, BxDF, BxDFFLags, BxDFI, BxDFReflTransFlags, TransportMode},
+    frame::Frame,
+    spectra::sampled_spectrum::SampledSpectrum,
+    vecmath::{Normal3f, Normalize, Point2f, Vector3f},
+    Float,
+};
+
+/// BxDF implementations handle computations in a local shading coordinate system;
+/// BSDF is a small wrapper around BxDF which handles the conversions between that
+/// shading coordinate system and the rendering coordinate system.
+pub struct BSDF {
+    bxdf: BxDF,
+    shading_frame: Frame,
+}
+
+impl BSDF {
+    // TODO we would like to implement Default() which initializes the bxdf as None,
+    // which is useful for transitions between different media that themselves do not scatter light;
+    // in which case, a bool() method that checks if bxdf.is_some() would also be useful. pg 544 of PBRTv4
+
+    pub fn new(ns: Normal3f, dpdus: Vector3f, bxdf: BxDF) -> BSDF {
+        let shading_frame = Frame::from_xz(dpdus.normalize(), Vector3f::from(ns));
+        BSDF {
+            bxdf,
+            shading_frame,
+        }
+    }
+
+    /// Provides information about the BSDF's high-level properties.
+    pub fn flags(&self) -> BxDFFLags {
+        self.bxdf.flags()
+    }
+
+    pub fn render_to_local(&self, v: Vector3f) -> Vector3f {
+        self.shading_frame.to_local_v(&v)
+    }
+
+    pub fn local_to_render(&self, v: Vector3f) -> Vector3f {
+        self.shading_frame.from_local_v(&v)
+    }
+
+    pub fn f(
+        &self,
+        wo_render: Vector3f,
+        wi_render: Vector3f,
+        mode: TransportMode,
+    ) -> SampledSpectrum {
+        let wi = self.render_to_local(wi_render);
+        let wo = self.render_to_local(wo_render);
+        if wo.z == 0.0 {
+            // In the case that wo lies directly on the surface's tangent plane,
+            // to avoid NaN propagation, return a zero-valued SampledSpectrum.
+            return SampledSpectrum::default();
+        }
+        self.bxdf.f(wo, wi, mode)
+    }
+
+    pub fn sample_f(
+        &self,
+        wo_render: Vector3f,
+        u: Float,
+        u2: Point2f,
+        mode: TransportMode,
+        sample_flags: BxDFReflTransFlags,
+    ) -> Option<BSDFSample> {
+        let wo = self.render_to_local(wo_render);
+        if wo.z == 0.0 || !((self.bxdf.flags().bits() & sample_flags.bits()) != 0) {
+            // TODO possibly better to return a default BSDFSample instead?
+            return None;
+        }
+        // Sample bxdf and return BSDFSample
+        let mut bs = self.bxdf.sample_f(wo, u, u2, mode, sample_flags)?;
+        if !bs.f || bs.pdf == 0.0 || bs.wi.z == 0.0 {
+            return None;
+        }
+        debug_assert!(bs.pdf > 0.0);
+
+        bs.wi = self.local_to_render(bs.wi);
+        Some(bs)
+    }
+
+    pub fn pdf(
+        &self,
+        wo_render: Vector3f,
+        wi_render: Vector3f,
+        mode: TransportMode,
+        sample_flags: BxDFReflTransFlags,
+    ) -> Float {
+        let wo = self.render_to_local(wo_render);
+        let wi = self.render_to_local(wi_render);
+        if wo.z == 0.0 {
+            return 0.0;
+        }
+        self.bxdf.pdf(wo, wi, mode, sample_flags)
+    }
+
+    pub fn rho_hd(&self, wo_render: Vector3f, uc: &[Float], u2: &[Point2f]) -> SampledSpectrum {
+        let wo = self.render_to_local(wo_render);
+        self.bxdf.rho_hd(wo, uc, u2)
+    }
+
+    pub fn rho_hh(&self, u1: &[Point2f], uc: &[Float], u2: &[Point2f]) -> SampledSpectrum {
+        self.bxdf.rho_hh(u1, uc, u2)
+    }
+}

--- a/src/bsdf.rs
+++ b/src/bsdf.rs
@@ -71,7 +71,7 @@ impl BSDF {
         }
         // Sample bxdf and return BSDFSample
         let mut bs = self.bxdf.sample_f(wo, u, u2, mode, sample_flags)?;
-        if !bs.f || bs.pdf == 0.0 || bs.wi.z == 0.0 {
+        if bs.f.is_zero() || bs.pdf == 0.0 || bs.wi.z == 0.0 {
             return None;
         }
         debug_assert!(bs.pdf > 0.0);

--- a/src/bxdf.rs
+++ b/src/bxdf.rs
@@ -1,0 +1,70 @@
+use bitflags::bitflags;
+
+pub trait BxDFI {
+    fn flags(&self) -> BxDFFLags;
+}
+
+bitflags! {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub struct BxDFFLags: u8
+    {
+        const UNSET = 0;
+        const REFLECTION = 1 << 0;
+        const TRANSMISSION = 1 << 1;
+        const DIFFUSE = 1 << 2;
+        const GLOSSY = 1 << 3;
+        const SPECULAR = 1 << 4;
+        const DIFFUSE_REFLECTION = Self::DIFFUSE.bits() | Self::REFLECTION.bits();
+        const DIFFUSE_TRANSMISSION = Self::DIFFUSE.bits() | Self::TRANSMISSION.bits();
+        const GLOSSY_REFLECTION = Self::GLOSSY.bits() | Self::REFLECTION.bits();
+        const GLOSSY_TRANSMISSION = Self::GLOSSY.bits() | Self::TRANSMISSION.bits();
+        const SPECULAR_REFLECTION = Self::SPECULAR.bits() | Self::REFLECTION.bits();
+        const SPECULAR_TRANSMISSION = Self::SPECULAR.bits() | Self::TRANSMISSION.bits();
+        const ALL = Self::DIFFUSE.bits() | Self::SPECULAR.bits() | Self::REFLECTION.bits() | Self::TRANSMISSION.bits();
+    }
+}
+
+impl BxDFFLags {
+    pub fn is_reflective(&self) -> bool {
+        (*self & Self::REFLECTION).bits() != 0
+    }
+
+    pub fn is_transmissive(&self) -> bool {
+        (*self & Self::TRANSMISSION).bits() != 0
+    }
+
+    pub fn is_diffuse(&self) -> bool {
+        (*self & Self::DIFFUSE).bits() != 0
+    }
+
+    pub fn is_glossy(&self) -> bool {
+        (*self & Self::GLOSSY).bits() != 0
+    }
+
+    pub fn is_specular(&self) -> bool {
+        (*self & Self::SPECULAR).bits() != 0
+    }
+
+    pub fn is_non_specular(&self) -> bool {
+        (*self & (Self::DIFFUSE | Self::GLOSSY)).bits() != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BxDFFLags;
+
+    #[test]
+    fn basic_bxdf_flags() {
+        let unset = BxDFFLags::UNSET;
+        assert!(!unset.is_diffuse());
+        assert!(!unset.is_transmissive());
+        assert!(!unset.is_glossy());
+        assert!(!unset.is_reflective());
+
+        let gt = BxDFFLags::GLOSSY_TRANSMISSION;
+        assert!(gt.is_glossy());
+        assert!(gt.is_transmissive());
+        assert!(!gt.is_diffuse());
+    }
+}

--- a/src/bxdf.rs
+++ b/src/bxdf.rs
@@ -1,7 +1,109 @@
 use bitflags::bitflags;
 
+use crate::{
+    spectra::sampled_spectrum::SampledSpectrum,
+    vecmath::{point::Point2f, Vector3f},
+    Float,
+};
+
+/// The BxDF Interface.
 pub trait BxDFI {
+    /// Returns the value of the distribution function for a given pair of directions wi and wo.
+    /// Both wi and wo must be provided in terms of the local reflection coordinate system.
+    /// The TransportMode dictates whether the outgoing direction wo is toward the camera or
+    /// toward the lightsource, which is necessary to handle cases where scattering is non-symmetric.
+    fn f(&self, wo: Vector3f, wi: Vector3f, mode: TransportMode) -> SampledSpectrum;
+
+    /// Uses importance sampling to draw a direction (wi) from a distribution function that approximates
+    /// the scattering function's shape.
+    /// u and uc are uniform samples.
+    /// uc will generally be used to choose between different kinds of sampling (e.g. reflection or transmission)
+    /// and u for the direction.
+    fn sample_f(
+        wo: Vector3f,
+        uc: Float,
+        u: Point2f,
+        mode: TransportMode,
+        sample_flags: BxDFReflTransFlags,
+    ) -> Option<BSDFSample>;
+
+    /// Returns the value of the PDF for a given pair of directions. This is useful for techniques like
+    /// multiple importance sampling that compare probabilities of multiple strategies for obstaining
+    /// a given sample.
+    fn pdf(
+        &self,
+        wo: Vector3f,
+        wi: Vector3f,
+        mode: TransportMode,
+        sample_flags: BxDFReflTransFlags,
+    ) -> Float;
+
     fn flags(&self) -> BxDFFLags;
+}
+
+pub struct BSDFSample {
+    /// Value of the BSDF f()
+    f: SampledSpectrum,
+    /// Sampled direction wi (given wo). BxDF specify wi wrt to the local reflection coordinate system;
+    /// BSDF::Sample_f() should transform wi to rendering space before returning, however.
+    wi: Vector3f,
+    /// PDF of wi with respect to solid angle
+    pdf: Float,
+    /// Characteristics of the particular sample
+    flags: BxDFFLags,
+    eta: Float,
+    /// Useful for a layered BxDF; in most cases, false.
+    pdf_is_proportional: bool,
+}
+
+impl BSDFSample {
+    pub fn new(f: SampledSpectrum, wi: Vector3f, pdf: Float, flags: BxDFFLags) -> BSDFSample {
+        BSDFSample {
+            f,
+            wi,
+            pdf,
+            flags,
+            eta: 1.0,
+            pdf_is_proportional: false,
+        }
+    }
+
+    pub fn is_reflection(&self) -> bool {
+        self.flags.is_reflective()
+    }
+
+    pub fn is_transmission(&self) -> bool {
+        self.flags.is_transmissive()
+    }
+
+    pub fn is_diffuse(&self) -> bool {
+        self.flags.is_diffuse()
+    }
+
+    pub fn is_glossy(&self) -> bool {
+        self.flags.is_glossy()
+    }
+
+    pub fn is_specular(&self) -> bool {
+        self.flags.is_specular()
+    }
+}
+
+pub enum TransportMode {
+    Radiance,
+    Importance,
+}
+
+bitflags! {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub struct BxDFReflTransFlags: u8
+    {
+        const UNSET = 0;
+        const REFLECTION = 1 << 0;
+        const TRANSMISSION = 1 << 1;
+        const ALL = Self::REFLECTION.bits() | Self::TRANSMISSION.bits();
+    }
+
 }
 
 bitflags! {

--- a/src/bxdf.rs
+++ b/src/bxdf.rs
@@ -97,19 +97,52 @@ pub trait BxDFI {
     }
 }
 
+pub enum BxDF {}
+
+impl BxDFI for BxDF {
+    fn f(&self, wo: Vector3f, wi: Vector3f, mode: TransportMode) -> SampledSpectrum {
+        todo!()
+    }
+
+    fn sample_f(
+        &self,
+        wo: Vector3f,
+        uc: Float,
+        u: Point2f,
+        mode: TransportMode,
+        sample_flags: BxDFReflTransFlags,
+    ) -> Option<BSDFSample> {
+        todo!()
+    }
+
+    fn pdf(
+        &self,
+        wo: Vector3f,
+        wi: Vector3f,
+        mode: TransportMode,
+        sample_flags: BxDFReflTransFlags,
+    ) -> Float {
+        todo!()
+    }
+
+    fn flags(&self) -> BxDFFLags {
+        todo!()
+    }
+}
+
 pub struct BSDFSample {
     /// Value of the BSDF f()
-    f: SampledSpectrum,
+    pub f: SampledSpectrum,
     /// Sampled direction wi (given wo). BxDF specify wi wrt to the local reflection coordinate system;
     /// BSDF::Sample_f() should transform wi to rendering space before returning, however.
-    wi: Vector3f,
+    pub wi: Vector3f,
     /// PDF of wi with respect to solid angle
-    pdf: Float,
+    pub pdf: Float,
     /// Characteristics of the particular sample
-    flags: BxDFFLags,
-    eta: Float,
+    pub flags: BxDFFLags,
+    pub eta: Float,
     /// Useful for a layered BxDF; in most cases, false.
-    pdf_is_proportional: bool,
+    pub pdf_is_proportional: bool,
 }
 
 impl BSDFSample {

--- a/src/bxdf.rs
+++ b/src/bxdf.rs
@@ -106,11 +106,15 @@ pub trait BxDFI {
     }
 }
 
-pub enum BxDF {}
+pub enum BxDF {
+    Diffuse(DiffuseBxDF),
+}
 
 impl BxDFI for BxDF {
     fn f(&self, wo: Vector3f, wi: Vector3f, mode: TransportMode) -> SampledSpectrum {
-        todo!()
+        match self {
+            BxDF::Diffuse(v) => v.f(wo, wi, mode),
+        }
     }
 
     fn sample_f(
@@ -121,7 +125,9 @@ impl BxDFI for BxDF {
         mode: TransportMode,
         sample_flags: BxDFReflTransFlags,
     ) -> Option<BSDFSample> {
-        todo!()
+        match self {
+            BxDF::Diffuse(v) => v.sample_f(wo, uc, u, mode, sample_flags),
+        }
     }
 
     fn pdf(
@@ -131,11 +137,15 @@ impl BxDFI for BxDF {
         mode: TransportMode,
         sample_flags: BxDFReflTransFlags,
     ) -> Float {
-        todo!()
+        match self {
+            BxDF::Diffuse(v) => v.pdf(wo, wi, mode, sample_flags),
+        }
     }
 
     fn flags(&self) -> BxDFFLags {
-        todo!()
+        match self {
+            BxDF::Diffuse(v) => v.flags(),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // TODO these shouldn't all be public; reorganize.
 
 pub mod bounding_box;
+mod bsdf;
 mod bxdf;
 pub mod camera;
 pub mod color;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // TODO these shouldn't all be public; reorganize.
 
 pub mod bounding_box;
+mod bxdf;
 pub mod camera;
 pub mod color;
 pub mod colorspace;

--- a/src/math.rs
+++ b/src/math.rs
@@ -7,7 +7,10 @@ use crate::{
     square_matrix::{Invertible, SquareMatrix},
 };
 
+pub const INV_PI: Float = 0.31830988618379067154;
 pub const INV_2PI: Float = 0.15915494309189533577;
+pub const PI_OVER_4: Float = 0.78539816339744830961;
+pub const PI_OVER_2: Float = 1.57079632679489661923;
 
 pub trait Sqrt {
     fn sqrt(self) -> Self;

--- a/src/math.rs
+++ b/src/math.rs
@@ -7,6 +7,8 @@ use crate::{
     square_matrix::{Invertible, SquareMatrix},
 };
 
+pub const INV_2PI: Float = 0.15915494309189533577;
+
 pub trait Sqrt {
     fn sqrt(self) -> Self;
 }

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -1,6 +1,6 @@
 use crate::{
     float::{next_float_down, Float, PI_F},
-    math::{lerp, safe_sqrt},
+    math::{lerp, safe_sqrt, INV_2PI},
     vecmath::{Point2f, Vector3f},
 };
 
@@ -109,6 +109,21 @@ pub fn sample_uniform_sphere(u: Point2f) -> Vector3f {
         y: r * Float::sin(phi),
         z,
     }
+}
+
+pub fn sample_uniform_hemisphere(u: Point2f) -> Vector3f {
+    let z = u[0];
+    let r = safe_sqrt(1.0 - z * z);
+    let phi = 2.0 * PI_F * u[1];
+    Vector3f {
+        x: r * Float::cos(phi),
+        y: r * Float::sin(phi),
+        z: z,
+    }
+}
+
+pub fn uniform_hemisphere_pdf() -> Float {
+    INV_2PI
 }
 
 // TODO get_camera_sample() pg 516; need to implement the Sampler interface/enum first.

--- a/src/spectra/sampled_spectrum.rs
+++ b/src/spectra/sampled_spectrum.rs
@@ -145,6 +145,14 @@ impl SampledSpectrum {
     }
 }
 
+impl Default for SampledSpectrum {
+    fn default() -> Self {
+        Self {
+            values: Default::default(),
+        }
+    }
+}
+
 impl Index<usize> for SampledSpectrum {
     type Output = Float;
 
@@ -210,6 +218,19 @@ impl_op_ex_commutative!(*|s1: &SampledSpectrum, v: &Float| -> SampledSpectrum {
     SampledSpectrum::new(result)
 });
 
+impl_op_ex!(/|s: &SampledSpectrum, v: &Float| -> SampledSpectrum
+{
+    debug_assert_ne!(v, &0.0);
+    debug_assert!(!v.is_nan());
+    let mut result = [0.0; NUM_SPECTRUM_SAMPLES];
+    for i in 0..NUM_SPECTRUM_SAMPLES
+    {
+        result[i] = s[i] / v;
+    }
+    debug_assert!(!result.has_nan());
+    SampledSpectrum::new(result)
+});
+
 impl_op_ex!(/|s1: &SampledSpectrum, s2: &SampledSpectrum| -> SampledSpectrum
 {
     let mut result = [0.0; NUM_SPECTRUM_SAMPLES];
@@ -250,6 +271,14 @@ impl_op_ex!(/=|s1: &mut SampledSpectrum, s2: &SampledSpectrum|
     for i in 0..NUM_SPECTRUM_SAMPLES
     {
         s1[i] /= s2[i];
+    }
+});
+
+impl_op_ex!(/=|s1: &mut SampledSpectrum, v: &Float|
+{
+    for i in 0..NUM_SPECTRUM_SAMPLES
+    {
+        s1[i] /= v;
     }
 });
 

--- a/src/spectra/sampled_spectrum.rs
+++ b/src/spectra/sampled_spectrum.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, Index, IndexMut};
+use std::ops::{Deref, Index, IndexMut, Not};
 
 use auto_ops::{impl_op_ex, impl_op_ex_commutative};
 
@@ -150,6 +150,19 @@ impl Default for SampledSpectrum {
         Self {
             values: Default::default(),
         }
+    }
+}
+
+impl Not for SampledSpectrum {
+    type Output = bool;
+
+    fn not(self) -> Self::Output {
+        for i in 0..NUM_SPECTRUM_SAMPLES {
+            if self.values[i] != 0.0 {
+                return false;
+            }
+        }
+        true
     }
 }
 

--- a/src/vecmath/mod.rs
+++ b/src/vecmath/mod.rs
@@ -48,6 +48,7 @@ mod length_fns;
 pub mod normal;
 pub mod normalize;
 pub mod point;
+pub mod spherical;
 pub mod tuple;
 mod tuple_fns;
 pub mod vector;

--- a/src/vecmath/spherical.rs
+++ b/src/vecmath/spherical.rs
@@ -1,0 +1,86 @@
+use crate::{float::PI_F, math::safe_acos, Float};
+
+use super::{vector::Vector3, Tuple3, Vector3f};
+
+pub fn spherical_triangle_area(a: Vector3f, b: Vector3f, c: Vector3f) -> Float {
+    Float::abs(2.0 * Float::atan2(a.dot(&b.cross(&c)), 1.0 + a.dot(&b) + a.dot(&c) + b.dot(&c)))
+}
+pub fn spherical_direction(sin_theta: Float, cos_theta: Float, phi: Float) -> Vector3f {
+    Vector3f::new(
+        sin_theta.clamp(-1.0, 1.0) * Float::cos(phi),
+        sin_theta.clamp(-1.0, 1.0) * Float::sin(phi),
+        cos_theta.clamp(-1.0, 1.0),
+    )
+}
+
+pub fn spherical_theta(v: Vector3f) -> Float {
+    safe_acos(v.z)
+}
+
+pub fn spherical_phi(v: Vector3f) -> Float {
+    let p = Float::atan2(v.y, v.x);
+    if p < 0.0 {
+        p + 2.0 * PI_F
+    } else {
+        p
+    }
+}
+
+pub fn cos_theta(w: Vector3f) -> Float {
+    w.z
+}
+
+pub fn cos2_theta(w: Vector3f) -> Float {
+    w.z * w.z
+}
+
+pub fn abs_cos_theta(w: Vector3f) -> Float {
+    Float::abs(w.z)
+}
+
+pub fn sin2_theta(w: Vector3f) -> Float {
+    Float::max(0.0, 1.0 - cos2_theta(w))
+}
+
+pub fn sin_theta(w: Vector3f) -> Float {
+    Float::sqrt(sin2_theta(w))
+}
+
+pub fn tan_theta(w: Vector3f) -> Float {
+    sin_theta(w) / cos_theta(w)
+}
+
+pub fn tan2_theta(w: Vector3f) -> Float {
+    sin2_theta(w) / cos2_theta(w)
+}
+
+pub fn cos_phi(w: Vector3f) -> Float {
+    let sin_theta = sin_theta(w);
+    if sin_theta == 0.0 {
+        1.0
+    } else {
+        Float::clamp(w.x / sin_theta, -1.0, 1.0)
+    }
+}
+
+pub fn sin_phi(w: Vector3f) -> Float {
+    let sin_theta = sin_theta(w);
+    if sin_theta == 0.0 {
+        1.0
+    } else {
+        Float::clamp(w.y / sin_theta, -1.0, 1.0)
+    }
+}
+
+pub fn cos_d_phi(wa: Vector3f, wb: Vector3f) -> Float {
+    let waxy = wa.x * wa.x + wa.y * wa.y;
+    let wbxy = wb.x * wb.x + wb.y * wb.y;
+    if waxy == 0.0 || wbxy == 0.0 {
+        return 1.0;
+    }
+    Float::clamp(
+        (wa.x * wb.x + wa.y * wb.y) / Float::sqrt(waxy * wbxy),
+        -1.0,
+        1.0,
+    )
+}

--- a/src/vecmath/spherical.rs
+++ b/src/vecmath/spherical.rs
@@ -84,3 +84,9 @@ pub fn cos_d_phi(wa: Vector3f, wb: Vector3f) -> Float {
         1.0,
     )
 }
+
+/// Checks if w and wp lie in the same hemisphere with respect to the
+/// surface normal in the BSDF coordinate system
+pub fn same_hemisphere(w: Vector3f, wp: Vector3f) -> bool {
+    w.z * wp.z > 0.0
+}


### PR DESCRIPTION
This implements the BxDF interface and enum and a diffuse BxDF. Also implements the wrapper BSDF for converting from render to shading local frame.
Will need other BxDF implementations later, but this should be sufficient for defining the interface.