### PR TITLE
Bvh

### DIFF
--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -129,7 +129,7 @@ impl BvhAggregate {
             .collect_vec();
 
         BvhAggregate {
-            max_prims_in_node: usize::max(255, max_prims_in_node),
+            max_prims_in_node: usize::min(255, max_prims_in_node),
             primitives,
             split_method,
             nodes,
@@ -443,5 +443,6 @@ mod tests {
         let bvh = BvhAggregate::new(prims, 1, crate::aggregate::SplitMethod::Middle);
         // The BVH boudning box should match the bounding box of the primitive
         assert_eq!(expected_bounds, bvh.bounds());
+        assert_eq!(1, bvh.max_prims_in_node);
     }
 }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -644,8 +644,6 @@ mod tests {
 
         let bvh = BvhAggregate::new(prims, 1, crate::aggregate::SplitMethod::Middle);
 
-        // TODO Assert on structure of bvh.
-
         let ray = Ray::new(Point3f::NEG_X * 10.0, Vector3f::X, None);
 
         let si = bvh.intersect(&ray, Float::INFINITY);

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -164,10 +164,11 @@ impl BvhAggregate {
         total_nodes.fetch_add(1, Ordering::SeqCst);
 
         // Compute the bounds of all primitives in the primitive range.
-        // The default of bounds should be an infinite extent, such that the union will restrict it.
         let bounds = bvh_primitives
             .iter()
-            .fold(Bounds3f::default(), |acc, p| acc.union(&p.bounds));
+            .fold(Bounds3f::new(Point3f::ZERO, Point3f::ZERO), |acc, p| {
+                acc.union(&p.bounds)
+            });
 
         if bounds.surface_area() == 0.0 || bvh_primitives.len() == 1 {
             // Create leaf BvhBuildNode
@@ -185,7 +186,9 @@ impl BvhAggregate {
             // Compute bound of primitive centroids and choose split dimension to be the largest dimension of the bounds.
             let centroid_bounds = bvh_primitives
                 .iter()
-                .fold(Bounds3f::default(), |acc, p| acc.union(&p.bounds));
+                .fold(Bounds3f::new(Point3f::ZERO, Point3f::ZERO), |acc, p| {
+                    acc.union(&p.bounds)
+                });
             let dim = centroid_bounds.max_dimension();
 
             if centroid_bounds.max[dim] == centroid_bounds.min[dim] {

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -663,6 +663,13 @@ mod tests {
 
         // TODO test the predicate intersection as well.
 
-        // TODO test a ray that misses entirely as well.
+        // This ray should not intersect the spheres.
+        let ray = Ray::new(
+            Point3f::NEG_X * 10.0 + Vector3f::Z * 1.001,
+            Vector3f::X,
+            None,
+        );
+        let si = bvh.intersect(&ray, Float::INFINITY);
+        assert!(si.is_none());
     }
 }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -155,8 +155,8 @@ impl PrimitiveI for BvhAggregate {
                     if to_visit_offset == 0 {
                         break;
                     }
-                    current_node_index = nodes_to_visit[to_visit_offset];
                     to_visit_offset -= 1;
+                    current_node_index = nodes_to_visit[to_visit_offset];
                 } else {
                     // Interior node; put far BVH node on nodes_to_visit stack,
                     // advance to the near node
@@ -174,8 +174,8 @@ impl PrimitiveI for BvhAggregate {
                 if to_visit_offset == 0 {
                     break;
                 }
-                current_node_index = nodes_to_visit[to_visit_offset];
                 to_visit_offset -= 1;
+                current_node_index = nodes_to_visit[to_visit_offset];
             }
         }
         false
@@ -599,10 +599,6 @@ mod tests {
         let prims = vec![prim];
         let bvh = BvhAggregate::new(prims, 1, crate::aggregate::SplitMethod::Middle);
 
-        // TODO Both this and the next test seem to fail because of a floating point precision bug
-        // in the sphere intersection code. Fix that and I think these should work, without issues around being exactly pointed at the center of the sphere.
-        // I'm going through and dealing with that floating point precision stuff now...
-
         let ray = Ray::new(Point3f::NEG_X * 5.0, Vector3f::X, None);
         let si = bvh.intersect(&ray, Float::INFINITY);
         assert!(si.is_some());
@@ -612,7 +608,7 @@ mod tests {
         // Ray started at -5, radius is 1, so it hits at 4.0.
         assert_approx_eq!(Float, si.t_hit, 4.0);
         // The hit should be at just about (-1, 0, 0)
-        assert_approx_eq!(Float, si.intr.p().x, -1.0);
+        assert_approx_eq!(Float, si.intr.p().x, -1.0, epsilon = 0.000001);
         assert_approx_eq!(Float, si.intr.p().y, 0.0);
         assert_approx_eq!(Float, si.intr.p().y, 0.0);
     }
@@ -620,7 +616,7 @@ mod tests {
     #[test]
     fn set_of_spheres() {
         let mut prims: Vec<Rc<Primitive>> = Vec::new();
-        for multiplier in [-3.5, 0.0, 3.5] {
+        for multiplier in [-3.5, 0.0, 5.0] {
             let radius = 1.0;
 
             let x_translate = Transform::translate(Vector3f::X * multiplier);
@@ -659,9 +655,9 @@ mod tests {
         // The normal should be in the negative X direction (we're hitting a sphere head-on in the positive X direction)
         assert_approx_eq!(Float, si.intr.shading.n.dot(&Normal3f::NEG_X), 1.0);
         // Ray started at -10, radius is 1 pushing the closest sphere's position to -3.5 - 1.0 == -4.5, so it hits at 5.5.
-        assert_approx_eq!(Float, si.t_hit, 5.5);
-        // The hit should be at just about (-1, 0, 0)
-        assert_approx_eq!(Float, si.intr.p().x, -5.5);
+        assert_approx_eq!(Float, si.t_hit, 5.5, epsilon = 0.00001);
+        // The hit should be at just about (-4.5, 0, 0), as center is at (-3.5, 0, 0) and it has a radius of 1.
+        assert_approx_eq!(Float, si.intr.p().x, -4.5, epsilon = 0.00001);
         assert_approx_eq!(Float, si.intr.p().y, 0.0);
         assert_approx_eq!(Float, si.intr.p().y, 0.0);
 

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -297,10 +297,13 @@ impl BvhAggregate {
 /// or the offset to the second child.
 pub enum LinearOffset {
     PrimitivesOffset(usize),
+    /// Only the second child offset is needed, as the first child
+    /// immediately follows the parent in the flat vector.
     SecondChildOffset(usize),
 }
 
 /// A BVH Node that is stored in a compact, linear representation of a BVH.
+#[repr(align(32))]
 pub struct LinearBvhNode {
     bounds: Bounds3f,
     offset: LinearOffset,

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -661,7 +661,8 @@ mod tests {
         assert_approx_eq!(Float, si.intr.p().y, 0.0);
         assert_approx_eq!(Float, si.intr.p().y, 0.0);
 
-        // TODO test the predicate intersection as well.
+        let hit = bvh.intersect_predicate(&ray, Float::INFINITY);
+        assert!(hit);
 
         // This ray should not intersect the spheres.
         let ray = Ray::new(
@@ -671,5 +672,7 @@ mod tests {
         );
         let si = bvh.intersect(&ray, Float::INFINITY);
         assert!(si.is_none());
+        let hit = bvh.intersect_predicate(&ray, Float::INFINITY);
+        assert!(!hit);
     }
 }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,0 +1,253 @@
+// TODO We'll probably iumplement either Middle or EqualCounts as SplitMethod first because they're easy,
+// but the others are more useful.
+// The BVHAggregate is defined in a different module because it's useful to split them, but they will
+//   also be in the Primitive enum and implement the PrimitiveI interface.
+// PBRT constructs with pointers first and then converts to a vec-based implementation.
+//   I could try to do the same I suppose, but I suspect we'll run into ownership issues.
+
+use std::{io::Split, rc::Rc, sync::Mutex};
+
+use itertools::Itertools;
+
+use crate::{
+    bounding_box::Bounds3f,
+    primitive::{Primitive, PrimitiveI},
+    ray::Ray,
+    shape::ShapeIntersection,
+    vecmath::Point3f,
+    Float,
+};
+
+pub enum SplitMethod {
+    // TODO Other split methods; Middle isn't very good, but simple for the first implementation.
+    Middle,
+}
+
+struct BvhAggregate {
+    max_prims_in_node: i32,
+    primitives: Vec<Rc<Primitive>>,
+    split_method: SplitMethod,
+    nodes: Vec<LinearBvhNode>,
+}
+
+impl PrimitiveI for BvhAggregate {
+    fn bounds(&self) -> Bounds3f {
+        todo!()
+    }
+
+    fn intersect(&self, ray: &Ray, t_max: Float) -> Option<ShapeIntersection> {
+        todo!()
+    }
+
+    fn intersect_predicate(&self, ray: &Ray, t_max: Float) -> bool {
+        todo!()
+    }
+}
+
+impl BvhAggregate {
+    pub fn new(
+        mut primitives: Vec<Rc<Primitive>>,
+        max_prims_in_node: i32,
+        split_method: SplitMethod,
+    ) -> BvhAggregate {
+        debug_assert!(!primitives.is_empty());
+
+        // Build BVH from primitives
+        // Initialize bvh_primitives array to store compact information about primitives while building.
+        let bvh_primitives: Vec<BvhPrimitive> = primitives
+            .iter()
+            .enumerate()
+            .map(|(i, &ref p)| BvhPrimitive {
+                primitive_index: i,
+                bounds: p.bounds(),
+            })
+            .collect_vec();
+
+        // TODO For now, I will not use a specific allocator. We will likely want to go add
+        // something like std::monotonic_buffer_resource later.
+
+        // This will store the primitives ordered such that the primitives in each leaf node occupy a
+        // contiguous range in the array for efficient access. It will be swapped with the original
+        // primitives array after the tree is constructed.
+        let mut ordered_primitives: Vec<Rc<Primitive>> = Vec::with_capacity(primitives.len());
+
+        // TODO The counters will probably be an Arc mutex actually.
+
+        // Keeps track of the number of nodes created; this makes it possible to allocate exactly
+        // the right size Vec for the LinearBvhNodes list.
+        let mut total_nodes = Mutex::new(0);
+
+        // Build the BVH according to the selected split method
+        let root = match split_method {
+            // The default for all splitting methods but HLBVH will be to use build_recursive().
+            _ => {
+                // Keeps track of where the next free entry in ordered_primitives is, so that leaf nodes can claim
+                // it as their starting primitive index, and reserve the next n slots for their n primitives.
+                let mut ordered_prims_offset = Mutex::new(0);
+                Self::build_recursive(
+                    &bvh_primitives,
+                    &mut total_nodes,
+                    &mut ordered_prims_offset,
+                    &mut ordered_primitives,
+                )
+            }
+        };
+
+        // Swap so that primtives stores the ordered primitives.
+        std::mem::swap(&mut primitives, &mut ordered_primitives);
+
+        // This can be a significant chunk of memory that we don't need anymore; free it.
+        drop(bvh_primitives);
+
+        let mut nodes: Vec<LinearBvhNode> = Vec::with_capacity(*total_nodes.lock().unwrap());
+
+        let mut offset = 0;
+        Self::flatten_bvh(&mut nodes, Some(Box::new(root)), &mut offset);
+        debug_assert_eq!(*total_nodes.lock().unwrap(), offset);
+
+        BvhAggregate {
+            max_prims_in_node: i32::max(255, max_prims_in_node),
+            primitives,
+            split_method,
+            nodes,
+        }
+    }
+
+    fn build_recursive(
+        bvh_primitives: &[BvhPrimitive],
+        total_nodes: &mut Mutex<usize>,
+        ordered_prims_offset: &mut Mutex<usize>,
+        ordered_prims: &mut Vec<Rc<Primitive>>,
+    ) -> BvhBuildNode {
+        todo!()
+    }
+
+    // Performs a depth-first traversal and stores the nodes in memory in linear order.
+    // offset tracks the current offset into the linear_nodes array.
+    // node is the root of the tree; this function is recursive, so it is also the root of sub-trees
+    // as this traverses down the tree.
+    fn flatten_bvh(
+        linear_nodes: &mut Vec<LinearBvhNode>,
+        node: Option<Box<BvhBuildNode>>,
+        offset: &mut usize,
+    ) -> usize {
+        let node = node.expect("flatten_bvh should be called with a valid root");
+
+        // PAPERDOC This is an interesting comparison to the PBRT implementation.
+        // The borrow checker would complain if we held both the linear_node as a mutable reference to
+        // the element in the array, and passed the array recrusively. We instead need to initialize
+        // the linear node locally, and set it after we're returned ownership of the vector.
+
+        let linear_node_bounds = node.bounds;
+
+        let node_offset = *offset;
+        *offset += 1;
+
+        let linear_node = if node.n_primitives > 0 {
+            // Leaf node!
+            debug_assert!(node.left_child.is_none() && node.right_child.is_none());
+            debug_assert!(node.n_primitives < 65536);
+            let linear_node_offset = LinearOffset::PrimitivesOffset(node.first_prim_offset);
+            let linear_nod_n_primitives = node.n_primitives as u16;
+            LinearBvhNode {
+                bounds: linear_node_bounds,
+                offset: linear_node_offset,
+                n_primitives: linear_nod_n_primitives,
+                axis: 0,
+            }
+        } else {
+            // Create interior flattened BVH node.
+            let linear_node_axis = node.split_axis as u8;
+            let linear_node_n_primitives = 0;
+            Self::flatten_bvh(linear_nodes, node.left_child, offset);
+            let second_child_offset = Self::flatten_bvh(linear_nodes, node.right_child, offset);
+            let linear_node_offset = LinearOffset::SecondChildOffset(second_child_offset);
+            LinearBvhNode {
+                bounds: linear_node_bounds,
+                offset: linear_node_offset,
+                n_primitives: linear_node_n_primitives,
+                axis: linear_node_axis,
+            }
+        };
+        linear_nodes[node_offset] = linear_node;
+
+        node_offset
+    }
+}
+
+/// Within a LinearBvhNode, stores either the offset to the primitives for the node,
+/// or the offset to the second child.
+pub enum LinearOffset {
+    PrimitivesOffset(usize),
+    SecondChildOffset(usize),
+}
+
+/// A BVH Node that is stored in a compact, linear representation of a BVH.
+pub struct LinearBvhNode {
+    bounds: Bounds3f,
+    offset: LinearOffset,
+    n_primitives: u16,
+    axis: u8,
+}
+
+/// Stores the bounding box and its index in the primitives array; used while building the BVH.
+struct BvhPrimitive {
+    primitive_index: usize,
+    bounds: Bounds3f,
+}
+
+impl BvhPrimitive {
+    pub fn centroid(&self) -> Point3f {
+        0.5 * self.bounds.min + (self.bounds.max * 0.5).into()
+    }
+}
+
+// TODO consider making BvhBuildNode an enum with an InteriorBvhBuildNode and a LeafBvhBuildNode.
+// That might be cleaner than checking for children, and possibly more space efficient.
+/// Used for representing a BVH node during construction of the BVH.
+struct BvhBuildNode {
+    bounds: Bounds3f,
+    // Nodes are leaves if both children are None.
+    left_child: Option<Box<BvhBuildNode>>,
+    right_child: Option<Box<BvhBuildNode>>,
+    split_axis: u8,
+    // The nodes in [first_prim_offset, first_prim_offset + n_primitives) are contained
+    // within this node.
+    first_prim_offset: usize,
+    n_primitives: i32,
+}
+
+impl BvhBuildNode {
+    pub fn leaf(first_prim_offset: usize, n_primitives: i32, bounds: Bounds3f) -> BvhBuildNode {
+        BvhBuildNode {
+            bounds,
+            left_child: None,
+            right_child: None,
+            split_axis: 0,
+            first_prim_offset,
+            n_primitives,
+        }
+    }
+
+    pub fn interior(
+        split_axis: u8,
+        left_child: Box<BvhBuildNode>,
+        right_child: Option<Box<BvhBuildNode>>,
+    ) -> BvhBuildNode {
+        // Interior nodes always have at least one child.
+        let bounds = if let Some(right) = &right_child {
+            left_child.bounds.union(&right.bounds)
+        } else {
+            left_child.bounds
+        };
+        // The primitive offset and num_primitives are 0 because interior nodes do not contain primitives.
+        BvhBuildNode {
+            bounds,
+            left_child: Some(left_child),
+            right_child: right_child,
+            split_axis,
+            first_prim_offset: 0,
+            n_primitives: 0,
+        }
+    }
+}

--- a/src/bounding_box.rs
+++ b/src/bounding_box.rs
@@ -245,7 +245,7 @@ impl<P: Point2, V: Vector2> Index<usize> for Bounds2<P, V> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct Bounds3<P, V> {
     pub min: P,
     pub max: P,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // TODO these shouldn't all be public; reorganize.
 
+mod aggregate;
 pub mod bounding_box;
 mod bsdf;
 mod bxdf;

--- a/src/material.rs
+++ b/src/material.rs
@@ -107,6 +107,12 @@ pub struct DiffuseMaterial {
     // TODO Add normal map and bump map, and update the getters for those.
 }
 
+impl DiffuseMaterial {
+    pub fn new(reflectance: SpectrumTexture) -> DiffuseMaterial {
+        DiffuseMaterial { reflectance }
+    }
+}
+
 impl MaterialI for DiffuseMaterial {
     type ConcreteBxDF = DiffuseBxDF;
 

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use crate::{
+    aggregate::BvhAggregate,
     bounding_box::Bounds3f,
     material::Material,
     ray::Ray,
@@ -28,6 +29,7 @@ pub trait PrimitiveI {
 pub enum Primitive {
     Simple(SimplePrimitive),
     Transformed(TransformedPrimitive),
+    BvhAggregate(BvhAggregate),
 }
 
 impl PrimitiveI for Primitive {
@@ -35,6 +37,7 @@ impl PrimitiveI for Primitive {
         match self {
             Primitive::Simple(p) => p.bounds(),
             Primitive::Transformed(p) => p.bounds(),
+            Primitive::BvhAggregate(a) => a.bounds(),
         }
     }
 
@@ -42,6 +45,7 @@ impl PrimitiveI for Primitive {
         match self {
             Primitive::Simple(p) => p.intersect(ray, t_max),
             Primitive::Transformed(p) => p.intersect(ray, t_max),
+            Primitive::BvhAggregate(a) => a.intersect(ray, t_max),
         }
     }
 
@@ -49,6 +53,7 @@ impl PrimitiveI for Primitive {
         match self {
             Primitive::Simple(p) => p.intersect_predicate(ray, t_max),
             Primitive::Transformed(p) => p.intersect_predicate(ray, t_max),
+            Primitive::BvhAggregate(a) => a.intersect_predicate(ray, t_max),
         }
     }
 }

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -61,8 +61,8 @@ impl PrimitiveI for Primitive {
 /// A Primitive which simply adds material information to the surface interaction of
 /// the shape.
 pub struct SimplePrimitive {
-    shape: Shape,
-    material: Rc<Material>,
+    pub shape: Shape,
+    pub material: Rc<Material>,
 }
 
 impl PrimitiveI for SimplePrimitive {

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -631,7 +631,6 @@ mod tests {
         let ray = Ray::new(ray.o, -ray.d, None);
         assert!(!sphere.intersect_predicate(&ray, Float::INFINITY));
 
-        // TODO This is returning a hit? Wtf?
         let ray = Ray::new(Point3f::new(0.0, 1.0001, -2.0), Vector3f::Z, None);
         assert!(!sphere.intersect_predicate(&ray, Float::INFINITY));
     }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -241,8 +241,8 @@ impl Sphere {
 impl Sphere {
     pub fn basic_intersect(&self, ray: &Ray, t_max: Float) -> Option<QuadricIntersection> {
         // Transform ray origin and direction to object space
-        let oi: Point3fi = self.object_from_render.apply(&ray.o).into();
-        let di: Vector3fi = self.object_from_render.apply(&ray.d).into();
+        let oi: Point3fi = self.object_from_render.apply(&Point3fi::from(ray.o));
+        let di: Vector3fi = self.object_from_render.apply(&Vector3fi::from(ray.d));
         // Solve quadratic equation to compute sphere t0 and t1
 
         // Compute sphere quadric coefficients
@@ -252,12 +252,8 @@ impl Sphere {
             oi.x().sqr() + oi.y().sqr() + oi.z().sqr() - Interval::from(self.radius).sqr();
         // Compute sphere quadratic discriminant
         let v = Vector3fi::from(oi - b / (2.0 * a) * di);
-        let length = v.length();
-        if length.is_nan() {
-            // This can occur with rays perfectly aimed at the center of the sphere.
-            warn!("Sphere intersection failed; intermediate NaN value");
-            return None;
-        }
+        let length: Interval = v.length();
+
         let discrim = 4.0
             * a
             * (Interval::from(self.radius) + length)
@@ -629,12 +625,13 @@ mod tests {
             1.0,
             360.0,
         );
-        let ray = Ray::new(Point3f::new(0.0, 1e-5, -2.0), Vector3f::Z, None);
+        let ray = Ray::new(Point3f::new(0.0, 0.0, -2.0), Vector3f::Z, None);
         assert!(sphere.intersect_predicate(&ray, Float::INFINITY));
 
         let ray = Ray::new(ray.o, -ray.d, None);
         assert!(!sphere.intersect_predicate(&ray, Float::INFINITY));
 
+        // TODO This is returning a hit? Wtf?
         let ray = Ray::new(Point3f::new(0.0, 1.0001, -2.0), Vector3f::Z, None);
         assert!(!sphere.intersect_predicate(&ray, Float::INFINITY));
     }
@@ -650,16 +647,16 @@ mod tests {
             0.5,
             360.0,
         );
-        let ray = Ray::new(Point3f::new(0.0, -2.0, 1e-5), Vector3f::Y, None);
+        let ray = Ray::new(Point3f::new(0.0, -2.0, 0.0), Vector3f::Y, None);
         assert!(sphere.intersect_predicate(&ray, Float::INFINITY));
 
         let ray = Ray::new(ray.o, -ray.d, None);
         assert!(!sphere.intersect_predicate(&ray, Float::INFINITY));
 
-        let ray = Ray::new(Point3f::new(0.0, 1e-5, 0.5001), Vector3f::Y, None);
+        let ray = Ray::new(Point3f::new(0.0, 0.0, 0.5001), Vector3f::Y, None);
         assert!(!sphere.intersect_predicate(&ray, Float::INFINITY));
 
-        let ray = Ray::new(Point3f::new(0.0, 1e-5, -0.5001), Vector3f::Y, None);
+        let ray = Ray::new(Point3f::new(0.0, 0.0, -0.5001), Vector3f::Y, None);
         assert!(!sphere.intersect_predicate(&ray, Float::INFINITY));
     }
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -55,7 +55,7 @@ impl SpectrumTextureI for SpectrumTexture {
 
 #[derive(Debug)]
 pub struct SpectrumConstantTexture {
-    value: Spectrum,
+    pub value: Spectrum,
 }
 
 impl SpectrumTextureI for SpectrumConstantTexture {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -382,18 +382,21 @@ impl Transformable for Point3fi {
         // Compute absolute error for transformed point
         let p_error: Vector3f = if self.is_exact() {
             // Compute error for transformed exact _p_
-            let err_x = Float::abs(transform.m[0][0] * x)
-                + Float::abs(transform.m[0][1] * y)
-                + Float::abs(transform.m[0][2] * z)
-                + Float::abs(transform.m[0][3]);
-            let err_y = Float::abs(transform.m[1][0] * x)
-                + Float::abs(transform.m[1][1] * y)
-                + Float::abs(transform.m[1][2] * z)
-                + Float::abs(transform.m[1][3]);
-            let err_z = Float::abs(transform.m[2][0] * x)
-                + Float::abs(transform.m[2][1] * y)
-                + Float::abs(transform.m[2][2] * z)
-                + Float::abs(transform.m[2][3]);
+            let err_x = gamma(3)
+                * (Float::abs(transform.m[0][0] * x)
+                    + Float::abs(transform.m[0][1] * y)
+                    + Float::abs(transform.m[0][2] * z)
+                    + Float::abs(transform.m[0][3]));
+            let err_y = gamma(3)
+                * (Float::abs(transform.m[1][0] * x)
+                    + Float::abs(transform.m[1][1] * y)
+                    + Float::abs(transform.m[1][2] * z)
+                    + Float::abs(transform.m[1][3]));
+            let err_z = gamma(3)
+                * (Float::abs(transform.m[2][0] * x)
+                    + Float::abs(transform.m[2][1] * y)
+                    + Float::abs(transform.m[2][2] * z)
+                    + Float::abs(transform.m[2][3]));
             Vector3f::new(err_x, err_y, err_z)
         } else {
             // Compute error for transformed approximate _p_
@@ -494,12 +497,12 @@ impl Transformable for Vector3fi {
 impl Transformable for Ray {
     fn apply(&self, transform: &Transform) -> Self {
         let o: Point3fi = transform.apply(&self.o).into();
-        let d: Vector3fi = transform.apply(&self.d).into();
+        let d: Vector3f = transform.apply(&self.d);
         // Offset ray origin to edge of error bounds and compute t_max
         let length_squared = d.length_squared();
         let o: Point3fi = if length_squared > 0.0 {
             let dt = d.abs().dot(&o.error().into()) / length_squared;
-            o + d * dt
+            o + (d * dt).into()
         } else {
             o
         };

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -253,8 +253,8 @@ impl Transform {
 
     pub fn inverse(&self) -> Transform {
         Transform {
-            m: self.m,
-            m_inv: self.m_inv,
+            m: self.m_inv,
+            m_inv: self.m,
         }
     }
 

--- a/src/vecmath/normal.rs
+++ b/src/vecmath/normal.rs
@@ -770,12 +770,12 @@ impl Normal3 for Normal3fi {
     }
 }
 
-impl Length<Float> for Normal3fi {
-    fn length_squared(&self) -> Float {
+impl Length<Interval> for Normal3fi {
+    fn length_squared(&self) -> Interval {
         length_squared3(self).into()
     }
 
-    fn length(&self) -> Float {
+    fn length(&self) -> Interval {
         length3(self).into()
     }
 }

--- a/src/vecmath/point.rs
+++ b/src/vecmath/point.rs
@@ -1084,12 +1084,12 @@ impl Point3 for Point3fi {
 
     fn distance(&self, p: &Self) -> Self::ElementType {
         debug_assert!(!self.has_nan());
-        Interval::from_val((self - p).length())
+        (self - p).length()
     }
 
     fn distance_squared(&self, p: &Self) -> Self::ElementType {
         debug_assert!(!self.has_nan());
-        Interval::from_val((self - p).length_squared())
+        (self - p).length_squared()
     }
 }
 

--- a/src/vecmath/tuple_fns.rs
+++ b/src/vecmath/tuple_fns.rs
@@ -166,20 +166,22 @@ pub fn angle_between<'a, V1, V2, V3, E>(v1: &'a V1, v2: &'a V2) -> Float
 where
     V1: Tuple3<E>,
     V2: Tuple3<E>,
-    V3: Tuple3<E> + Length<Float>,
+    V3: Tuple3<E> + Length<E>,
     &'a V1: Add<&'a V2, Output = V3>,
     &'a V2: Add<&'a V1, Output = V3> + Sub<&'a V1, Output = V3>,
     E: TupleElement + MulAdd + DifferenceOfProducts + Into<Float>,
 {
+    // TODO This function could also report an Interval for interval types e.g. two Vector3fi.
+
     // TODO I think we could simplify the constraints on this function.
     // E might be able to be omitted, and instead specified as a constraint on the ElementType of V1.
     // We could also omit V3 by replacing it with the Output of V1 + V2, I think.
     debug_assert!(!v1.has_nan());
     debug_assert!(!v2.has_nan());
     if dot3(v1, v2).into() < 0.0 {
-        PI_F - 2.0 * safe_asin((v1 + v2).length() / 2.0)
+        PI_F - 2.0 * safe_asin((v1 + v2).length().into() / 2.0)
     } else {
-        2.0 * safe_asin((v2 - v1).length() / 2.0)
+        2.0 * safe_asin((v2 - v1).length().into() / 2.0)
     }
 }
 

--- a/src/vecmath/vector.rs
+++ b/src/vecmath/vector.rs
@@ -1425,13 +1425,13 @@ impl Vector3 for Vector3fi {
     }
 }
 
-impl Length<Float> for Vector3fi {
-    fn length_squared(&self) -> Float {
-        length_squared3(self).into()
+impl Length<Interval> for Vector3fi {
+    fn length_squared(&self) -> Interval {
+        length_squared3(self)
     }
 
-    fn length(&self) -> Float {
-        length3(self).into()
+    fn length(&self) -> Interval {
+        length3(self)
     }
 }
 


### PR DESCRIPTION
We'll want better splitting methods for BVH in the future, and there's still some TODOs such as parallelizing construction (with Rayon, that shouldn't actually be that hard), but this is a working implementation with pretty good test coverage. It should be sufficient for getting us on the correct order of magnitude for ray-scene intersection complexity.

Also includes some bug fixes for other modules, including some for Transform (darn transposed assignments...) and some floating point accuracy fixes for Ray transforms and Sphere intersections.