### PR TITLE
Take Tuple params by value, not reference

### DIFF
--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -640,7 +640,7 @@ mod tests {
         assert!(si.is_some());
         let si = si.unwrap();
         // The normal should be in the negative X direction (we're hitting a sphere head-on in the positive X direction)
-        assert_approx_eq!(Float, si.intr.shading.n.dot(&Normal3f::NEG_X), 1.0);
+        assert_approx_eq!(Float, si.intr.shading.n.dot(Normal3f::NEG_X), 1.0);
         // Ray started at -5, radius is 1, so it hits at 4.0.
         assert_approx_eq!(Float, si.t_hit, 4.0);
         // The hit should be at just about (-1, 0, 0)
@@ -688,7 +688,7 @@ mod tests {
         assert!(si.is_some());
         let si = si.unwrap();
         // The normal should be in the negative X direction (we're hitting a sphere head-on in the positive X direction)
-        assert_approx_eq!(Float, si.intr.shading.n.dot(&Normal3f::NEG_X), 1.0);
+        assert_approx_eq!(Float, si.intr.shading.n.dot(Normal3f::NEG_X), 1.0);
         // Ray started at -10, radius is 1 pushing the closest sphere's position to -3.5 - 1.0 == -4.5, so it hits at 5.5.
         assert_approx_eq!(Float, si.t_hit, 5.5, epsilon = 0.00001);
         // The hit should be at just about (-4.5, 0, 0), as center is at (-3.5, 0, 0) and it has a radius of 1.

--- a/src/bounding_box.rs
+++ b/src/bounding_box.rs
@@ -33,8 +33,8 @@ where
 {
     pub fn new(p1: P, p2: P) -> Self {
         Self {
-            min: Tuple2::min(&p1, &p2),
-            max: Tuple2::max(&p1, &p2),
+            min: Tuple2::min(p1, p2),
+            max: Tuple2::max(p1, p2),
             phantom_vector: PhantomData,
         }
     }
@@ -53,9 +53,9 @@ where
         P::new(self[corner & 1].x(), self[(corner & 2 != 0) as usize].y())
     }
 
-    pub fn union_point(&self, p: &P) -> Self {
-        let min = Tuple2::min(&self.min, &p);
-        let max = Tuple2::max(&self.max, &p);
+    pub fn union_point(&self, p: P) -> Self {
+        let min = Tuple2::min(self.min, p);
+        let max = Tuple2::max(self.max, p);
         // Set values directly to maintain degeneracy and avoid infinite extents.
         // See PBRTv4 pg 99.
         Self {
@@ -66,8 +66,8 @@ where
     }
 
     pub fn union(&self, other: &Self) -> Self {
-        let min = Tuple2::min(&self.min, &other.min);
-        let max = Tuple2::max(&self.max, &other.max);
+        let min = Tuple2::min(self.min, other.min);
+        let max = Tuple2::max(self.max, other.max);
         // Set values directly to maintain degeneracy and avoid infinite extents.
         // See PBRTv4 pg 99.
         Self {
@@ -80,8 +80,8 @@ where
     /// None if the bounds do not intersect.
     /// Else, the intersection of the two bounds.
     pub fn intersect(&self, other: &Self) -> Option<Self> {
-        let min = Tuple2::max(&self.min, &other.min);
-        let max = Tuple2::min(&self.max, &other.max);
+        let min = Tuple2::max(self.min, other.min);
+        let max = Tuple2::min(self.max, other.max);
 
         if min.x() >= max.x() || min.y() >= max.y() {
             return None;
@@ -175,13 +175,13 @@ where
         P::new(
             P::ElementType::from_float(lerp(
                 t.x().into_float(),
-                &self.min.x().into_float(),
-                &self.max.x().into_float(),
+                self.min.x().into_float(),
+                self.max.x().into_float(),
             )),
             P::ElementType::from_float(lerp(
                 t.y().into_float(),
-                &self.min.y().into_float(),
-                &self.max.y().into_float(),
+                self.min.y().into_float(),
+                self.max.y().into_float(),
             )),
         )
     }
@@ -259,8 +259,8 @@ where
 {
     pub fn new(p1: P, p2: P) -> Self {
         Self {
-            min: Tuple3::min(&p1, &p2),
-            max: Tuple3::max(&p1, &p2),
+            min: Tuple3::min(p1, p2),
+            max: Tuple3::max(p1, p2),
             phantom_vector: PhantomData,
         }
     }
@@ -283,9 +283,9 @@ where
         )
     }
 
-    pub fn union_point(&self, p: &P) -> Self {
-        let min = Tuple3::min(&self.min, &p);
-        let max = Tuple3::max(&self.max, &p);
+    pub fn union_point(&self, p: P) -> Self {
+        let min = Tuple3::min(self.min, p);
+        let max = Tuple3::max(self.max, p);
         // Set values directly to maintain degeneracy and avoid infinite extents.
         // See PBRTv4 pg 99.
         Self {
@@ -296,8 +296,8 @@ where
     }
 
     pub fn union(&self, other: &Self) -> Self {
-        let min = Tuple3::min(&self.min, &other.min);
-        let max = Tuple3::max(&self.max, &other.max);
+        let min = Tuple3::min(self.min, other.min);
+        let max = Tuple3::max(self.max, other.max);
         // Set values directly to maintain degeneracy and avoid infinite extents.
         // See PBRTv4 pg 99.
         Self {
@@ -310,8 +310,8 @@ where
     /// None if the bounds do not intersect.
     /// Else, the intersection of the two bounds.
     pub fn intersect(&self, other: &Self) -> Option<Self> {
-        let min = Tuple3::max(&self.min, &other.min);
-        let max = Tuple3::min(&self.max, &other.max);
+        let min = Tuple3::max(self.min, other.min);
+        let max = Tuple3::min(self.max, other.max);
 
         // PAPERDOC - PBRTv4 has an IsEmpty() function that must be called after this
         // function in case the bounds don't intersect; but that intent is not clear
@@ -426,18 +426,18 @@ where
         P::new(
             P::ElementType::from_float(lerp(
                 t.x().into_float(),
-                &self.min.x().into_float(),
-                &self.max.x().into_float(),
+                self.min.x().into_float(),
+                self.max.x().into_float(),
             )),
             P::ElementType::from_float(lerp(
                 t.y().into_float(),
-                &self.min.y().into_float(),
-                &self.max.y().into_float(),
+                self.min.y().into_float(),
+                self.max.y().into_float(),
             )),
             P::ElementType::from_float(lerp(
                 t.z().into_float(),
-                &self.min.z().into_float(),
-                &self.max.z().into_float(),
+                self.min.z().into_float(),
+                self.max.z().into_float(),
             )),
         )
     }
@@ -467,7 +467,7 @@ where
     pub fn bounding_sphere(&self) -> Sphere<P, P::ElementType> {
         let center: P = (self.min + V::from(self.max)) / P::ElementType::from_i32(2);
         let radius: P::ElementType = if self.inside(&center) {
-            center.distance(&self.max)
+            center.distance(self.max)
         } else {
             P::ElementType::from_i32(0)
         };
@@ -709,7 +709,7 @@ mod tests {
         let max = Point2i::new(1, 1);
         let bounds = Bounds2i::new(min, max);
         let new_point = Point2i::new(-1, -1);
-        let union = bounds.union_point(&new_point);
+        let union = bounds.union_point(new_point);
         assert_eq!(Point2i::new(-1, -1), union.min);
         assert_eq!(Point2i::new(1, 1), union.max);
     }
@@ -720,7 +720,7 @@ mod tests {
         let max = Point3i::new(1, 1, 1);
         let bounds = Bounds3i::new(min, max);
         let new_point = Point3i::new(-1, -1, -1);
-        let union = bounds.union_point(&new_point);
+        let union = bounds.union_point(new_point);
         assert_eq!(Point3i::new(-1, -1, -1), union.min);
         assert_eq!(Point3i::new(1, 1, 1), union.max);
     }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -250,7 +250,7 @@ impl CameraBase {
 
     /// u - the fraction between the shutter open and shutter close.
     pub fn sample_time(&self, u: Float) -> Float {
-        lerp(u, &self.shutter_open, &self.shutter_close)
+        lerp(u, self.shutter_open, self.shutter_close)
     }
 
     pub fn generate_ray_differential<T: CameraI>(
@@ -342,14 +342,14 @@ impl CameraBase {
             Vector3f::Z + self.min_dir_differential_x,
             None,
         );
-        let tx = -(n_down_z.dot_vector(&x_ray.o.into()) - d) / n_down_z.dot_vector(&x_ray.d);
+        let tx = -(n_down_z.dot_vector(x_ray.o.into()) - d) / n_down_z.dot_vector(x_ray.d);
         let y_ray = Ray::new(
             Point3f::ZERO + self.min_pos_differential_y,
             Vector3f::Z + self.min_dir_differential_y,
             None,
         );
 
-        let ty = -(n_down_z.dot_vector(&y_ray.o.into()) - d) / n_down_z.dot_vector(&y_ray.d);
+        let ty = -(n_down_z.dot_vector(y_ray.o.into()) - d) / n_down_z.dot_vector(y_ray.d);
         let px = x_ray.get(tx);
         let py = y_ray.get(ty);
 

--- a/src/direction_cone.rs
+++ b/src/direction_cone.rs
@@ -50,7 +50,7 @@ impl DirectionCone {
     pub fn bound_subtended_directions(b: &Bounds3f, p: Point3f) -> DirectionCone {
         let bounding_sphere = b.bounding_sphere();
         // Check if the point is inside the bounding sphere
-        if p.distance_squared(&bounding_sphere.center)
+        if p.distance_squared(bounding_sphere.center)
             < bounding_sphere.radius * bounding_sphere.radius
         {
             return DirectionCone::entire_sphere();
@@ -58,7 +58,7 @@ impl DirectionCone {
         // Compute and return the DirectionCone for the bounding sphere
         let w = (bounding_sphere.center - p).normalize();
         let sin2_theta_max = bounding_sphere.radius * bounding_sphere.radius
-            / bounding_sphere.center.distance_squared(&p);
+            / bounding_sphere.center.distance_squared(p);
 
         let cos_theta_max = safe_sqrt(1.0 - sin2_theta_max);
         DirectionCone::new(w, cos_theta_max)
@@ -70,7 +70,7 @@ impl DirectionCone {
 
     /// Returns true if the vector w is within the bounding direction
     pub fn inside(&self, w: Vector3f) -> bool {
-        !self.is_empty() && self.w.dot(&w.normalize()) >= self.cos_theta
+        !self.is_empty() && self.w.dot(w.normalize()) >= self.cos_theta
     }
 
     pub fn union(&self, other: &DirectionCone) -> DirectionCone {
@@ -84,7 +84,7 @@ impl DirectionCone {
         // Handle the case where one cone is inside the other
         let theta_a = safe_acos(self.cos_theta);
         let theta_b = safe_acos(other.cos_theta);
-        let theta_d = self.w.angle_between(&other.w);
+        let theta_d = self.w.angle_between(other.w);
         if Float::min(theta_d + theta_b, PI_F) <= theta_a {
             return self.clone();
         }
@@ -98,7 +98,7 @@ impl DirectionCone {
         }
         // Find the merged cones' axis and return the cone union
         let theta_r = theta_o - theta_a;
-        let wr = self.w.cross(&other.w);
+        let wr = self.w.cross(other.w);
         if wr.length_squared() == 0.0 {
             return DirectionCone::entire_sphere();
         }

--- a/src/film.rs
+++ b/src/film.rs
@@ -1011,8 +1011,8 @@ impl VisibleSurface {
         let set = true;
         let p = si.p();
         let wo = si.interaction.wo;
-        let n = si.interaction.n.face_forward_v(&wo);
-        let ns = si.shading.n.face_forward_v(&wo);
+        let n = si.interaction.n.face_forward_v(wo);
+        let ns = si.shading.n.face_forward_v(wo);
         let uv = si.interaction.uv;
         let time = si.interaction.time;
         let dpdx = si.dpdx;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -98,8 +98,8 @@ impl FilterI for BoxFilter {
 
     fn sample(&self, u: Point2f) -> FilterSample {
         let p = Point2f::new(
-            lerp(u[0], &-self.radius.x, &self.radius.x),
-            lerp(u[1], &-self.radius.y, &self.radius.y),
+            lerp(u[0], -self.radius.x, self.radius.x),
+            lerp(u[1], -self.radius.y, self.radius.y),
         );
         FilterSample { p, weight: 1.0 }
     }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -12,12 +12,12 @@ impl Frame {
     }
 
     pub fn from_xz(x: Vector3f, z: Vector3f) -> Frame {
-        let y = z.cross(&x);
+        let y = z.cross(x);
         Frame::new(x, y, z)
     }
 
     pub fn from_xy(x: Vector3f, y: Vector3f) -> Frame {
-        let z = x.cross(&y);
+        let z = x.cross(y);
         Frame::new(x, y, z)
     }
 
@@ -37,14 +37,14 @@ impl Frame {
     }
 
     pub fn to_local_v(&self, v: &Vector3f) -> Vector3f {
-        Vector3f::new(v.dot(&self.x), v.dot(&self.y), v.dot(&self.z))
+        Vector3f::new(v.dot(self.x), v.dot(self.y), v.dot(self.z))
     }
 
     pub fn to_local_n(&self, n: &Normal3f) -> Normal3f {
         Normal3f::new(
-            n.dot_vector(&self.x),
-            n.dot_vector(&self.y),
-            n.dot_vector(&self.z),
+            n.dot_vector(self.x),
+            n.dot_vector(self.y),
+            n.dot_vector(self.z),
         )
     }
 

--- a/src/integrator.rs
+++ b/src/integrator.rs
@@ -535,7 +535,7 @@ impl RandomWalkIntegrator {
             return le;
         }
         let f = f.unwrap();
-        let fcos = f * wp.abs_dot_normal(&isect.shading.n);
+        let fcos = f * wp.abs_dot_normal(isect.shading.n);
 
         // Recursively trace ray to estimate incident radiance at surface
         let ray = isect.interaction.spawn_ray(wp);
@@ -756,7 +756,7 @@ impl SimplePathIntegrator {
                     break;
                 }
                 let bs = bs.unwrap();
-                beta *= bs.f * bs.wi.abs_dot_normal(&isect.shading.n) / bs.pdf;
+                beta *= bs.f * bs.wi.abs_dot_normal(isect.shading.n) / bs.pdf;
                 specular_bounce = bs.is_specular();
                 *ray = isect.interaction.spawn_ray(bs.wi);
             } else {
@@ -770,12 +770,11 @@ impl SimplePathIntegrator {
                     let wi = sample_uniform_hemisphere(sampler.get_2d());
                     let pdf = uniform_hemisphere_pdf();
                     let wi = if (flags.is_reflective()
-                        && wo.dot_normal(&isect.interaction.n)
-                            * wi.dot_normal(&isect.interaction.n)
+                        && wo.dot_normal(isect.interaction.n) * wi.dot_normal(isect.interaction.n)
                             < 0.0)
                         || (flags.is_transmissive()
-                            && wo.dot_normal(&isect.interaction.n)
-                                * wi.dot_normal(&isect.interaction.n)
+                            && wo.dot_normal(isect.interaction.n)
+                                * wi.dot_normal(isect.interaction.n)
                                 > 0.0)
                     {
                         -wi
@@ -787,7 +786,7 @@ impl SimplePathIntegrator {
                 beta *= bsdf
                     .f(wo, wi, crate::bxdf::TransportMode::Radiance)
                     .unwrap()
-                    * wi.abs_dot_normal(&isect.shading.n)
+                    * wi.abs_dot_normal(isect.shading.n)
                     / pdf;
                 specular_bounce = false;
                 *ray = isect.interaction.spawn_ray(wi);

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -115,7 +115,7 @@ impl SurfaceInteraction {
         flip_normal: bool,
     ) -> SurfaceInteraction {
         let normal_sign = if flip_normal { -1.0 } else { 1.0 };
-        let normal = normal_sign * Normal3f::from(dpdu.cross(&dpdv).normalize());
+        let normal = normal_sign * Normal3f::from(dpdu.cross(dpdv).normalize());
         let interaction = Interaction::new(pi, normal, uv, wo, time);
         SurfaceInteraction {
             interaction,
@@ -233,19 +233,19 @@ impl SurfaceInteraction {
         }
 
         if ray.auxiliary.as_ref().is_some_and(|aux| {
-            self.interaction.n.dot_vector(&aux.rx_direction) != 0.0
-                && self.interaction.n.dot_vector(&aux.ry_direction) != 0.0
+            self.interaction.n.dot_vector(aux.rx_direction) != 0.0
+                && self.interaction.n.dot_vector(aux.ry_direction) != 0.0
         }) {
             let aux = ray.auxiliary.as_ref().unwrap();
             // Estimate screen-space change in pt using ray differentials
             // Compute auxiliary intersecrtion points with plane, px and py
-            let d = -self.interaction.n.dot_vector(&self.p().into());
-            let tx = (-self.interaction.n.dot_vector(&aux.rx_origin.into()) - d)
-                / self.interaction.n.dot_vector(&aux.rx_direction);
+            let d = -self.interaction.n.dot_vector(self.p().into());
+            let tx = (-self.interaction.n.dot_vector(aux.rx_origin.into()) - d)
+                / self.interaction.n.dot_vector(aux.rx_direction);
             debug_assert!(tx.is_finite() && !tx.is_nan());
             let px = aux.rx_origin + tx * aux.rx_direction;
-            let ty = (-self.interaction.n.dot_vector(&aux.ry_origin.into()) - d)
-                / self.interaction.n.dot_vector(&aux.ry_direction);
+            let ty = (-self.interaction.n.dot_vector(aux.ry_origin.into()) - d)
+                / self.interaction.n.dot_vector(aux.ry_direction);
             debug_assert!(ty.is_finite() && !ty.is_nan());
             let py = aux.ry_origin + ty * aux.ry_direction;
 
@@ -263,16 +263,16 @@ impl SurfaceInteraction {
         }
 
         // Estimate screen-space changes in (u, v).
-        let ata00 = self.dpdu.dot(&self.dpdu);
-        let ata01 = self.dpdu.dot(&self.dpdv);
-        let ata11 = self.dpdv.dot(&self.dpdv);
+        let ata00 = self.dpdu.dot(self.dpdu);
+        let ata01 = self.dpdu.dot(self.dpdv);
+        let ata11 = self.dpdv.dot(self.dpdv);
         let inv_det = 1.0 / Float::difference_of_products(ata00, ata11, ata01, ata01);
         let inv_det = if inv_det.is_finite() { inv_det } else { 0.0 };
 
-        let atb0x = self.dpdu.dot(&self.dpdx);
-        let atb1x = self.dpdv.dot(&self.dpdx);
-        let atb0y = self.dpdu.dot(&self.dpdy);
-        let atb1y = self.dpdv.dot(&self.dpdy);
+        let atb0x = self.dpdu.dot(self.dpdx);
+        let atb1x = self.dpdv.dot(self.dpdx);
+        let atb0y = self.dpdu.dot(self.dpdy);
+        let atb1y = self.dpdv.dot(self.dpdy);
 
         // Compute u and v derivatives wrt x and y
         self.dudx = Float::difference_of_products(ata11, atb0x, ata01, atb1x) * inv_det;
@@ -326,9 +326,9 @@ impl SurfaceInteraction {
         self.shading.n = ns;
         debug_assert_ne!(self.shading.n, Normal3f::ZERO);
         if orientation_is_authoritative {
-            self.interaction.n = self.interaction.n.face_forward(&self.shading.n);
+            self.interaction.n = self.interaction.n.face_forward(self.shading.n);
         } else {
-            self.shading.n = self.shading.n.face_forward(&self.interaction.n);
+            self.shading.n = self.shading.n.face_forward(self.interaction.n);
         }
 
         self.shading.dpdu = dpdus;

--- a/src/light.rs
+++ b/src/light.rs
@@ -412,7 +412,7 @@ impl LightI for PointLight {
     ) -> Option<LightLiSample> {
         let p = self.base.render_from_light.apply(&Point3f::ZERO);
         let wi = (p - ctx.p()).normalize();
-        let li = self.scale * self.i.sample(&lambda) / p.distance_squared(&ctx.p());
+        let li = self.scale * self.i.sample(&lambda) / p.distance_squared(ctx.p());
         // TODO I do think this is correct compared to PBRT,
         // but I don't love just leaving many fields default().
         // Can we represent this better? Option?
@@ -612,7 +612,7 @@ impl LightI for DiffuseAreaLight {
         lambda: &SampledWavelengths,
     ) -> SampledSpectrum {
         // Check for zero emitted radiance from point on area light
-        if !self.two_sided && n.dot_vector(&w) < 0.0 {
+        if !self.two_sided && n.dot_vector(w) < 0.0 {
             return SampledSpectrum::from_const(0.0);
         }
         // TODO Check alpha mask with alpha texture and UV.

--- a/src/math.rs
+++ b/src/math.rs
@@ -232,10 +232,10 @@ impl IsNeg for Interval {
     }
 }
 
-pub fn lerp<'a, T>(t: Float, a: &'a T, b: &'a T) -> T
+pub fn lerp<T>(t: Float, a: T, b: T) -> T
 where
     T: Add<T, Output = T>,
-    &'a T: Mul<Float, Output = T>,
+    T: Mul<Float, Output = T>,
 {
     a * (1.0 - t) + b * t
 }
@@ -375,7 +375,7 @@ mod tests {
         let a = 0.0;
         let b = 10.0;
         let x = 0.45;
-        assert_eq!(4.5, super::lerp(x, &a, &b));
+        assert_eq!(4.5, super::lerp(x, a, b));
     }
 
     #[test]

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -164,7 +164,7 @@ impl PrimitiveI for TransformedPrimitive {
         debug_assert!(si.t_hit <= 1.001 * t_max);
 
         si.intr = self.render_from_primitive.apply(&si.intr);
-        debug_assert!(si.intr.interaction.n.dot(&si.intr.shading.n) >= 0.0);
+        debug_assert!(si.intr.interaction.n.dot(si.intr.shading.n) >= 0.0);
 
         Some(si)
     }

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -51,9 +51,9 @@ impl Ray {
 
     pub fn offset_ray_origin(pi: Point3fi, n: Normal3f, w: Vector3f) -> Point3f {
         // Find vector offset to corner of error bounds and compute initial p0
-        let d = n.abs().dot_vector(&pi.error());
+        let d = n.abs().dot_vector(pi.error());
         let mut offset = d * Vector3f::from(n);
-        if w.dot_normal(&n) < 0.0 {
+        if w.dot_normal(n) < 0.0 {
             offset = -offset;
         }
         let mut po = Point3f::from(pi) + offset;

--- a/src/shape/sphere.rs
+++ b/src/shape/sphere.rs
@@ -144,7 +144,7 @@ impl Sphere {
         // Compute sphere hit position and phi
         let mut p_hit = Point3f::from(oi) + Float::from(t_shape_hit) * Vector3f::from(di);
         // Refine sphere intersection point
-        p_hit *= self.radius / p_hit.distance(&Point3f::ZERO);
+        p_hit *= self.radius / p_hit.distance(Point3f::ZERO);
 
         if p_hit.x == 0.0 && p_hit.y == 0.0 {
             p_hit.x = 1e-5 * self.radius;
@@ -170,7 +170,7 @@ impl Sphere {
             // Compute sphere hit position and phi
             p_hit = Point3f::from(oi) + Float::from(t_shape_hit) * Vector3f::from(di);
             // Refine sphere intersection point
-            p_hit *= self.radius / p_hit.distance(&Point3f::ZERO);
+            p_hit *= self.radius / p_hit.distance(Point3f::ZERO);
 
             if p_hit.x == 0.0 && p_hit.y == 0.0 {
                 p_hit.x = 1e-5 * self.radius;
@@ -231,13 +231,13 @@ impl Sphere {
             * (self.theta_z_max - self.theta_z_min))
             * Vector3f::new(p_hit.x(), p_hit.y(), p_hit.z());
         // Compute coefficients for fundamental forms
-        let e1 = dpdu.dot(&dpdu);
-        let f1 = dpdu.dot(&dpdv);
-        let g1 = dpdv.dot(&dpdv);
-        let n = dpdu.cross(&dpdv).normalize();
-        let e = n.dot(&d2pduu);
-        let f = n.dot(&d2pduv);
-        let g = n.dot(&d2pdvv);
+        let e1 = dpdu.dot(dpdu);
+        let f1 = dpdu.dot(dpdv);
+        let g1 = dpdv.dot(dpdv);
+        let n = dpdu.cross(dpdv).normalize();
+        let e = n.dot(d2pduu);
+        let f = n.dot(d2pduv);
+        let g = n.dot(d2pdvv);
 
         // Compute $\dndu$ and $\dndv$ from fundamental form coefficients
         let egf2 = Float::difference_of_products(e1, g1, f1, f1);
@@ -304,7 +304,7 @@ impl ShapeI for Sphere {
     fn sample(&self, u: Point2f) -> Option<ShapeSample> {
         let mut p_obj: Point3f = Point3f::ZERO + sample_uniform_sphere(u) * self.radius;
         // Reproject p_obj to sphere surface and compute p_obj_error
-        p_obj *= self.radius / p_obj.distance(&Point3f::ZERO);
+        p_obj *= self.radius / p_obj.distance(Point3f::ZERO);
         let p_obj_error: Vector3f = gamma(5) * Vector3f::from(p_obj).abs();
 
         // Compute surface normal for sphere sample and return shape sample
@@ -340,7 +340,7 @@ impl ShapeI for Sphere {
         let p_center: Point3f = self.render_from_object.apply(&Point3f::ZERO);
         let p_origin: Point3f = ctx.offset_ray_origin_pt(p_center);
         // Sample uniformly on sphere if $\pt{}$ is inside it
-        if p_origin.distance_squared(&p_center) <= self.radius * self.radius {
+        if p_origin.distance_squared(p_center) <= self.radius * self.radius {
             // Sample shape by area and compute incident direction _wi_
             let mut ss = self.sample(u).expect("Sphere sample() failed!");
             ss.intr.time = ctx.time;
@@ -351,7 +351,7 @@ impl ShapeI for Sphere {
             let wi = wi.normalize();
 
             // Convert area sampling PDF in _ss_ to solid angle measure
-            ss.pdf /= ss.intr.n.abs_dot_vector(&-wi) / ctx.p().distance_squared(&ss.intr.p());
+            ss.pdf /= ss.intr.n.abs_dot_vector(-wi) / ctx.p().distance_squared(ss.intr.p());
             if ss.pdf.is_infinite() {
                 return None;
             }
@@ -360,7 +360,7 @@ impl ShapeI for Sphere {
 
         // Sample sphere uniformly inside subtended cone
         // Compute quantities related to the $\theta_\roman{max}$ for cone
-        let sin_theta_max: Float = self.radius / ctx.p().distance(&p_center);
+        let sin_theta_max: Float = self.radius / ctx.p().distance(p_center);
         let sin2_theta_max: Float = sin_theta_max * sin_theta_max;
         let cos_theta_max: Float = safe_sqrt(1.0 - sin2_theta_max);
         let mut one_minus_cos_theta_max: Float = 1.0 - cos_theta_max;
@@ -424,7 +424,7 @@ impl ShapeI for Sphere {
     fn pdf_with_context(&self, ctx: &ShapeSampleContext, wi: Vector3f) -> Float {
         let p_center = self.render_from_object.apply(&Point3f::ZERO);
         let p_origin = ctx.offset_ray_origin_pt(p_center);
-        if p_origin.distance_squared(&p_center) <= self.radius * self.radius {
+        if p_origin.distance_squared(p_center) <= self.radius * self.radius {
             // Return solid angle PDF for point inside sphere
             // Intersect sample ray with shape geometry
             let ray = ctx.spawn_ray(wi);
@@ -436,8 +436,8 @@ impl ShapeI for Sphere {
 
             // Compute PDF in solid angle measure from shape intersection point
             let pdf = (1.0 / self.area())
-                / isect.intr.interaction.n.abs_dot_vector(&-wi)
-                / ctx.p().distance_squared(&isect.intr.p());
+                / isect.intr.interaction.n.abs_dot_vector(-wi)
+                / ctx.p().distance_squared(isect.intr.p());
             if pdf.is_infinite() {
                 return 0.0;
             } else {
@@ -445,7 +445,7 @@ impl ShapeI for Sphere {
             }
         }
         // Compute general solid angle sphere PDF
-        let sin2_theta_max = self.radius * self.radius / ctx.p().distance_squared(&p_center);
+        let sin2_theta_max = self.radius * self.radius / ctx.p().distance_squared(p_center);
         let cos_theta_max = safe_sqrt(1.0 - sin2_theta_max);
         let mut one_minus_cos_theta_max = 1.0 - cos_theta_max;
         // Compute more accurate _oneMinusCosThetaMax_ for small solid angle

--- a/src/spectra/sampled_wavelengths.rs
+++ b/src/spectra/sampled_wavelengths.rs
@@ -33,7 +33,7 @@ impl SampledWavelengths {
         let mut lambda = [0.0; NUM_SPECTRUM_SAMPLES];
 
         // Sample first wavelength using u
-        lambda[0] = lerp(u, &lambda_min, &lambda_max);
+        lambda[0] = lerp(u, lambda_min, lambda_max);
 
         // Initialzie lambda for remaining wavelengths
         let delta = (lambda_max - lambda_min) / (NUM_SPECTRUM_SAMPLES as Float);

--- a/src/spectra/spectrum.rs
+++ b/src/spectra/spectrum.rs
@@ -423,7 +423,7 @@ impl SpectrumI for PiecewiseLinearSpectrum {
         debug_assert!(lambda >= self.lambdas[o] && lambda <= self.lambdas[o + 1]);
 
         let t = (lambda - self.lambdas[o]) / (self.lambdas[o + 1] - self.lambdas[o]);
-        lerp(t, &self.values[o], &self.values[o + 1])
+        lerp(t, self.values[o], self.values[o + 1])
     }
 
     fn max_value(&self) -> Float {
@@ -867,7 +867,7 @@ mod tests {
         let n = 900000;
         for _ in 0..n {
             let u = between.sample(&mut rng);
-            let lambda = lerp::<Float>(u, &LAMBDA_MIN, &LAMBDA_MAX);
+            let lambda = lerp::<Float>(u, LAMBDA_MIN, LAMBDA_MAX);
             let pdf = 1.0 / (LAMBDA_MAX - LAMBDA_MIN);
             unifsum += (Spectrum::get_cie(CIE::X).get(lambda)
                 + Spectrum::get_cie(CIE::Z).get(lambda)

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -254,9 +254,8 @@ impl Transform {
         for i in 0..3 {
             for j in 0..3 {
                 let kronecker = if i == j { 1.0 } else { 0.0 };
-                r.m[i][j] =
-                    kronecker - 2.0 / u.dot(&u) * u[i] * u[j] - 2.0 / v.dot(&v) * v[i] * v[j]
-                        + 4.0 * u.dot(&v) / (u.dot(&u) * v.dot(&v)) * v[i] * u[j];
+                r.m[i][j] = kronecker - 2.0 / u.dot(u) * u[i] * u[j] - 2.0 / v.dot(v) * v[i] * v[j]
+                    + 4.0 * u.dot(v) / (u.dot(u) * v.dot(v)) * v[i] * u[j];
             }
         }
 
@@ -290,8 +289,8 @@ impl Transform {
         world_from_camera.m[3][3] = 1.0;
 
         let dir = (look_at - pos).normalize();
-        let right = up.normalize().cross(&dir).normalize();
-        let new_up = dir.cross(&right);
+        let right = up.normalize().cross(dir).normalize();
+        let new_up = dir.cross(right);
 
         world_from_camera.m[0][0] = right.x;
         world_from_camera.m[1][0] = right.y;
@@ -551,7 +550,7 @@ impl TransformableRay for Ray {
         // Offset ray origin to edge of error bounds and compute t_max
         let length_squared = d.length_squared();
         let o: Point3fi = if length_squared > 0.0 {
-            let dt = d.abs().dot(&o.error().into()) / length_squared;
+            let dt = d.abs().dot(o.error().into()) / length_squared;
             if let Some(t_max) = t_max {
                 *t_max = *t_max - dt;
             }
@@ -595,7 +594,7 @@ impl Transformable for Bounds3f {
         );
 
         for i in 2..8 {
-            out = out.union_point(&transform.apply(&self.corner(i)));
+            out = out.union_point(transform.apply(&self.corner(i)));
         }
 
         out
@@ -621,7 +620,7 @@ impl Transformable for SurfaceInteraction {
             dndu: t.apply(&self.dndu),
             dndv: t.apply(&self.dndv),
             shading: SurfaceInteractionShading {
-                n: t.apply(&self.shading.n).normalize().face_forward(&n),
+                n: t.apply(&self.shading.n).normalize().face_forward(n),
                 dpdu: t.apply(&self.shading.dpdu),
                 dpdv: t.apply(&self.shading.dpdv),
                 dndu: t.apply(&self.shading.dndu),
@@ -742,7 +741,7 @@ impl InverseTransformableRay for Ray {
                 o.y().width() / 2.0,
                 o.z().width() / 2.0,
             );
-            let dt = d.abs().dot(&o_error) / length_squared;
+            let dt = d.abs().dot(o_error) / length_squared;
             if let Some(t_max) = t_max {
                 *t_max = *t_max - dt;
             }

--- a/src/vecmath/frame.rs
+++ b/src/vecmath/frame.rs
@@ -16,16 +16,16 @@ impl Frame {
         debug_assert!(Float::abs(x.length_squared() - 1.0) < 1e-4);
         debug_assert!(Float::abs(y.length_squared() - 1.0) < 1e-4);
         debug_assert!(Float::abs(z.length_squared() - 1.0) < 1e-4);
-        debug_assert!(x.abs_dot(&y) < 1e-4);
-        debug_assert!(y.abs_dot(&z) < 1e-4);
-        debug_assert!(z.abs_dot(&x) < 1e-4);
+        debug_assert!(x.abs_dot(y) < 1e-4);
+        debug_assert!(y.abs_dot(z) < 1e-4);
+        debug_assert!(z.abs_dot(x) < 1e-4);
         Frame { x, y, z }
     }
 
     pub fn from_xz(x: Vector3f, z: Vector3f) -> Frame {
         Frame {
             x,
-            y: z.cross(&x),
+            y: z.cross(x),
             z,
         }
     }
@@ -34,7 +34,7 @@ impl Frame {
         Frame {
             x,
             y,
-            z: x.cross(&y),
+            z: x.cross(y),
         }
     }
 
@@ -55,9 +55,9 @@ impl Frame {
 
     pub fn to_local(&self, v: Vector3f) -> Vector3f {
         Vector3f {
-            x: v.dot(&self.x),
-            y: v.dot(&self.y),
-            z: v.dot(&self.z),
+            x: v.dot(self.x),
+            y: v.dot(self.y),
+            z: v.dot(self.z),
         }
     }
 
@@ -65,9 +65,9 @@ impl Frame {
     // requires improving dot() in a similar manner. Traits as a better alternative to overloading.
     pub fn to_local_n(&self, n: Normal3f) -> Normal3f {
         Normal3f {
-            x: n.dot_vector(&self.x),
-            y: n.dot_vector(&self.y),
-            z: n.dot_vector(&self.z),
+            x: n.dot_vector(self.x),
+            y: n.dot_vector(self.y),
+            z: n.dot_vector(self.z),
         }
     }
 }

--- a/src/vecmath/normal.rs
+++ b/src/vecmath/normal.rs
@@ -34,31 +34,31 @@ pub trait Normal3:
     type AssociatedVectorType: Vector3;
 
     /// Compute the dot product of two normals.
-    fn dot(&self, n: &Self) -> Self::ElementType;
+    fn dot(&self, n: Self) -> Self::ElementType;
 
     /// Compute the dot product with a vector.
-    fn dot_vector(&self, v: &Self::AssociatedVectorType) -> Self::ElementType;
+    fn dot_vector(&self, v: Self::AssociatedVectorType) -> Self::ElementType;
 
     /// Compute the dot product of two normals and take the absolute value.
-    fn abs_dot(&self, n: &Self) -> Self::ElementType;
+    fn abs_dot(&self, n: Self) -> Self::ElementType;
 
     /// Compute the dot product with a vector and take the absolute value.
-    fn abs_dot_vector(&self, v: &Self::AssociatedVectorType) -> Self::ElementType;
+    fn abs_dot_vector(&self, v: Self::AssociatedVectorType) -> Self::ElementType;
 
     /// Cross this normal with a vector.
     /// Note that you cannot take the cross product of two normals.
-    fn cross(&self, v: &Self::AssociatedVectorType) -> Self::AssociatedVectorType;
+    fn cross(&self, v: Self::AssociatedVectorType) -> Self::AssociatedVectorType;
 
     /// Get the angle between this and another normal.
     /// Both must be normalized.
-    fn angle_between(&self, n: &Self) -> Float;
+    fn angle_between(&self, n: Self) -> Float;
 
     /// Get the angle between this normal and a vector.
-    fn angle_between_vector(&self, v: &Self::AssociatedVectorType) -> Float;
+    fn angle_between_vector(&self, v: Self::AssociatedVectorType) -> Float;
 
-    fn face_forward(&self, n2: &Self) -> Self;
+    fn face_forward(&self, n2: Self) -> Self;
 
-    fn face_forward_v(&self, v: &Self::AssociatedVectorType) -> Self;
+    fn face_forward_v(&self, v: Self::AssociatedVectorType) -> Self;
 }
 
 // ---------------------------------------------------------------------------
@@ -137,7 +137,7 @@ impl Tuple3<i32> for Normal3i {
         &mut self.z
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         lerp(t, a, b)
     }
 
@@ -159,52 +159,52 @@ impl Normal3 for Normal3i {
     type AssociatedVectorType = Vector3i;
 
     /// Compute the dot product of two normals.
-    fn dot(&self, n: &Self) -> i32 {
-        dot3i(self, n)
+    fn dot(&self, n: Self) -> i32 {
+        dot3i(*self, n)
     }
 
     /// Compute the dot product with a vector.
-    fn dot_vector(&self, v: &Vector3i) -> i32 {
-        dot3i(self, v)
+    fn dot_vector(&self, v: Vector3i) -> i32 {
+        dot3i(*self, v)
     }
 
     /// Compute the dot product of two normals and take the absolute value.
-    fn abs_dot(&self, n: &Self) -> i32 {
-        abs_dot3i(self, n)
+    fn abs_dot(&self, n: Self) -> i32 {
+        abs_dot3i(*self, n)
     }
 
     /// Compute the dot product with a vector and take the absolute value.
-    fn abs_dot_vector(&self, v: &Vector3i) -> i32 {
-        abs_dot3i(self, v)
+    fn abs_dot_vector(&self, v: Vector3i) -> i32 {
+        abs_dot3i(*self, v)
     }
 
     /// Cross this normal with a vector.
     /// Note that you cannot take the cross product of two normals.
-    fn cross(&self, v: &Vector3i) -> Vector3i {
+    fn cross(&self, v: Vector3i) -> Vector3i {
         // Note that integer based vectors don't need EFT methods.
-        cross_i32(self, v)
+        cross_i32(*self, v)
     }
 
-    fn angle_between(&self, n: &Normal3i) -> Float {
+    fn angle_between(&self, n: Normal3i) -> Float {
         angle_between::<Normal3f, Normal3f, Normal3f, Float>(
-            &Normal3f::from(self).normalize(),
-            &Normal3f::from(n).normalize(),
+            Normal3f::from(self).normalize(),
+            Normal3f::from(n).normalize(),
         )
     }
 
-    fn angle_between_vector(&self, v: &Self::AssociatedVectorType) -> Float {
+    fn angle_between_vector(&self, v: Self::AssociatedVectorType) -> Float {
         angle_between::<Normal3f, Vector3f, Vector3f, Float>(
-            &Normal3f::from(self).normalize(),
-            &Vector3f::from(v).normalize(),
+            Normal3f::from(self).normalize(),
+            Vector3f::from(v).normalize(),
         )
     }
 
-    fn face_forward(&self, n2: &Self) -> Self {
-        face_forward(self, n2)
+    fn face_forward(&self, n2: Self) -> Self {
+        face_forward(*self, n2)
     }
 
-    fn face_forward_v(&self, v: &Self::AssociatedVectorType) -> Self {
-        face_forward(self, v)
+    fn face_forward_v(&self, v: Self::AssociatedVectorType) -> Self {
+        face_forward(*self, v)
     }
 }
 
@@ -446,7 +446,7 @@ impl Tuple3<Float> for Normal3f {
         self.z
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         lerp(t, a, b)
     }
 
@@ -480,18 +480,18 @@ impl Normal3 for Normal3f {
     type AssociatedVectorType = Vector3f;
 
     /// Compute the dot product of two normals.
-    fn dot(&self, n: &Self) -> Float {
-        dot3(self, n)
+    fn dot(&self, n: Self) -> Float {
+        dot3(*self, n)
     }
 
     /// Compute the dot with a vector.
-    fn dot_vector(&self, v: &Vector3f) -> Float {
-        dot3(self, v)
+    fn dot_vector(&self, v: Vector3f) -> Float {
+        dot3(*self, v)
     }
 
     /// Compute the dot product of two normals and take the absolute value.
-    fn abs_dot(&self, n: &Self) -> Float {
-        abs_dot3(self, n)
+    fn abs_dot(&self, n: Self) -> Float {
+        abs_dot3(*self, n)
     }
 
     // TODO Rather than having a *_vector(), we could probably restructure these functions
@@ -501,35 +501,35 @@ impl Normal3 for Normal3f {
     // so I had forgotten some useful patterns like this...
 
     /// Compute the dot with a vector and take the absolute value.
-    fn abs_dot_vector(&self, v: &Vector3f) -> Float {
-        abs_dot3(self, v)
+    fn abs_dot_vector(&self, v: Vector3f) -> Float {
+        abs_dot3(*self, v)
     }
 
     /// Takes the cross of this normal with a vector.
     /// Note that you cannot take the cross product of two normals.
     /// Uses an EFT method for calculating the value with minimal error without
     /// casting to f64. See PBRTv4 3.3.2.
-    fn cross(&self, v: &Vector3f) -> Vector3f {
-        cross::<Normal3f, Vector3f, Vector3f, Float>(self, v)
+    fn cross(&self, v: Vector3f) -> Vector3f {
+        cross::<Normal3f, Vector3f, Vector3f, Float>(*self, v)
     }
 
     /// Get the angle between this and another normal.
     /// Both must be normalized.
-    fn angle_between(&self, n: &Normal3f) -> Float {
-        angle_between::<Normal3f, Normal3f, Normal3f, Float>(self, n)
+    fn angle_between(&self, n: Normal3f) -> Float {
+        angle_between::<Normal3f, Normal3f, Normal3f, Float>(*self, n)
     }
 
     /// Get the angle between this normal and a vector.
-    fn angle_between_vector(&self, v: &Vector3f) -> Float {
-        angle_between::<Normal3f, Vector3f, Vector3f, Float>(self, v)
+    fn angle_between_vector(&self, v: Vector3f) -> Float {
+        angle_between::<Normal3f, Vector3f, Vector3f, Float>(*self, v)
     }
 
-    fn face_forward(&self, n2: &Self) -> Self {
-        face_forward(self, n2)
+    fn face_forward(&self, n2: Self) -> Self {
+        face_forward(*self, n2)
     }
 
-    fn face_forward_v(&self, v: &Self::AssociatedVectorType) -> Self {
-        face_forward(self, v)
+    fn face_forward_v(&self, v: Self::AssociatedVectorType) -> Self {
+        face_forward(*self, v)
     }
 }
 
@@ -549,7 +549,7 @@ impl IndexMut<usize> for Normal3f {
 
 impl HasNan for Normal3f {
     fn has_nan(&self) -> bool {
-        has_nan3(self)
+        has_nan3(*self)
     }
 }
 
@@ -719,11 +719,11 @@ impl Tuple3<Interval> for Normal3fi {
         &mut self.z
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         Normal3fi {
-            x: lerp(t, &a.x, &b.x),
-            y: lerp(t, &a.y, &b.y),
-            z: lerp(t, &a.z, &b.z),
+            x: lerp(t, a.x, b.x),
+            y: lerp(t, a.y, b.y),
+            z: lerp(t, a.z, b.z),
         }
     }
 }
@@ -733,40 +733,40 @@ impl Normal3 for Normal3fi {
 
     type AssociatedVectorType = Vector3fi;
 
-    fn dot(&self, n: &Self) -> Self::ElementType {
-        dot3(self, n)
+    fn dot(&self, n: Self) -> Self::ElementType {
+        dot3(*self, n)
     }
 
-    fn dot_vector(&self, v: &Self::AssociatedVectorType) -> Self::ElementType {
-        dot3(self, v)
+    fn dot_vector(&self, v: Self::AssociatedVectorType) -> Self::ElementType {
+        dot3(*self, v)
     }
 
-    fn abs_dot(&self, n: &Self) -> Self::ElementType {
-        abs_dot3(self, n)
+    fn abs_dot(&self, n: Self) -> Self::ElementType {
+        abs_dot3(*self, n)
     }
 
-    fn abs_dot_vector(&self, v: &Self::AssociatedVectorType) -> Self::ElementType {
-        abs_dot3(self, v)
+    fn abs_dot_vector(&self, v: Self::AssociatedVectorType) -> Self::ElementType {
+        abs_dot3(*self, v)
     }
 
-    fn cross(&self, v: &Self::AssociatedVectorType) -> Self::AssociatedVectorType {
-        cross::<Normal3fi, Vector3fi, Vector3fi, Interval>(self, v)
+    fn cross(&self, v: Self::AssociatedVectorType) -> Self::AssociatedVectorType {
+        cross::<Normal3fi, Vector3fi, Vector3fi, Interval>(*self, v)
     }
 
-    fn angle_between(&self, n: &Self) -> Float {
-        angle_between::<Normal3fi, Normal3fi, Normal3fi, Interval>(self, n)
+    fn angle_between(&self, n: Self) -> Float {
+        angle_between::<Normal3fi, Normal3fi, Normal3fi, Interval>(*self, n)
     }
 
-    fn angle_between_vector(&self, v: &Self::AssociatedVectorType) -> Float {
-        angle_between::<Normal3fi, Vector3fi, Vector3fi, Interval>(self, v)
+    fn angle_between_vector(&self, v: Self::AssociatedVectorType) -> Float {
+        angle_between::<Normal3fi, Vector3fi, Vector3fi, Interval>(*self, v)
     }
 
-    fn face_forward(&self, n2: &Self) -> Self {
-        face_forward(self, n2)
+    fn face_forward(&self, n2: Self) -> Self {
+        face_forward(*self, n2)
     }
 
-    fn face_forward_v(&self, v: &Self::AssociatedVectorType) -> Self {
-        face_forward(self, v)
+    fn face_forward_v(&self, v: Self::AssociatedVectorType) -> Self {
+        face_forward(*self, v)
     }
 }
 
@@ -909,44 +909,44 @@ mod tests {
     fn normal_normal_dot() {
         let v1 = Normal3f::new(0.0, 1.0, 2.0);
         let v2 = Normal3f::new(3.0, 4.0, 5.0);
-        assert_eq!(14.0, v1.dot(&v2));
+        assert_eq!(14.0, v1.dot(v2));
 
         let v1 = Normal3i::new(0, 1, 2);
         let v2 = Normal3i::new(3, 4, 5);
-        assert_eq!(14, v1.dot(&v2));
+        assert_eq!(14, v1.dot(v2));
     }
 
     #[test]
     fn normal_vector_dot() {
         let v1 = Normal3f::new(0.0, 1.0, 2.0);
         let v2 = Vector3f::new(3.0, 4.0, 5.0);
-        assert_eq!(14.0, v1.dot_vector(&v2));
+        assert_eq!(14.0, v1.dot_vector(v2));
 
         let v1 = Normal3i::new(0, 1, 2);
         let v2 = Vector3i::new(3, 4, 5);
-        assert_eq!(14, v1.dot_vector(&v2));
+        assert_eq!(14, v1.dot_vector(v2));
     }
 
     #[test]
     fn normal_normal_abs_dot() {
         let v1 = Normal3f::new(0.0, 1.0, 2.0);
         let v2 = -Normal3f::new(3.0, 4.0, 5.0);
-        assert_eq!(14.0, v1.abs_dot(&v2));
+        assert_eq!(14.0, v1.abs_dot(v2));
 
         let v1 = Normal3i::new(0, 1, 2);
         let v2 = -Normal3i::new(3, 4, 5);
-        assert_eq!(14, v1.abs_dot(&v2));
+        assert_eq!(14, v1.abs_dot(v2));
     }
 
     #[test]
     fn normal_vector_abs_dot() {
         let v1 = Normal3f::new(0.0, 1.0, 2.0);
         let v2 = -Vector3f::new(3.0, 4.0, 5.0);
-        assert_eq!(14.0, v1.abs_dot_vector(&v2));
+        assert_eq!(14.0, v1.abs_dot_vector(v2));
 
         let v1 = Normal3i::new(0, 1, 2);
         let v2 = -Vector3i::new(3, 4, 5);
-        assert_eq!(14, v1.abs_dot_vector(&v2));
+        assert_eq!(14, v1.abs_dot_vector(v2));
     }
 
     #[test]
@@ -956,11 +956,11 @@ mod tests {
 
         let n = Normal3i::new(3, -3, 1);
         let v = Vector3i::new(4, 9, 2);
-        assert_eq!(Vector3i::new(-15, -2, 39), n.cross(&v));
+        assert_eq!(Vector3i::new(-15, -2, 39), n.cross(v));
 
         let n = Normal3f::new(3.0, -3.0, 1.0);
         let v = Vector3f::new(4.0, 9.0, 2.0);
-        assert_eq!(Vector3f::new(-15.0, -2.0, 39.0), n.cross(&v));
+        assert_eq!(Vector3f::new(-15.0, -2.0, 39.0), n.cross(v));
     }
 
     #[test]
@@ -968,7 +968,7 @@ mod tests {
         let n1 = Normal3i::new(1, 2, 3);
         let n2 = Normal3i::new(3, 4, 5);
 
-        assert_eq!(0.18623877, n1.angle_between(&n2));
+        assert_eq!(0.18623877, n1.angle_between(n2));
     }
 
     #[test]
@@ -976,7 +976,7 @@ mod tests {
         let n1 = Normal3i::new(1, 2, 3);
         let v2 = Vector3i::new(3, 4, 5);
 
-        assert_eq!(0.18623877, n1.angle_between_vector(&v2));
+        assert_eq!(0.18623877, n1.angle_between_vector(v2));
     }
 
     #[test]
@@ -984,7 +984,7 @@ mod tests {
         let n1 = Normal3f::new(1.0, 2.0, 3.0).normalize();
         let n2 = Normal3f::new(3.0, 4.0, 5.0).normalize();
 
-        assert_eq!(0.18623877, n1.angle_between(&n2));
+        assert_eq!(0.18623877, n1.angle_between(n2));
     }
 
     #[test]
@@ -992,7 +992,7 @@ mod tests {
         let n1 = Normal3f::new(1.0, 2.0, 3.0).normalize();
         let v2 = Vector3f::new(3.0, 4.0, 5.0).normalize();
 
-        assert_eq!(0.18623877, n1.angle_between_vector(&v2));
+        assert_eq!(0.18623877, n1.angle_between_vector(v2));
     }
 
     #[test]
@@ -1143,7 +1143,7 @@ mod tests {
     fn normal3i_lerp() {
         let n1 = Normal3i::new(0, 100, 1000);
         let n2 = Normal3i::new(10, 200, 2000);
-        let n3 = Normal3i::lerp(0.5, &n1, &n2);
+        let n3 = Normal3i::lerp(0.5, n1, n2);
         assert_eq!(5, n3[0]);
         assert_eq!(150, n3[1]);
         assert_eq!(1500, n3[2]);
@@ -1159,7 +1159,7 @@ mod tests {
     fn normal3f_lerp() {
         let n1 = Normal3f::new(0.0, 100.0, 1000.0);
         let n2 = Normal3f::new(10.0, 200.0, 2000.0);
-        let n3 = Normal3f::lerp(0.5, &n1, &n2);
+        let n3 = Normal3f::lerp(0.5, n1, n2);
         assert_eq!(5.0, n3[0]);
         assert_eq!(150.0, n3[1]);
         assert_eq!(1500.0, n3[2]);

--- a/src/vecmath/point.rs
+++ b/src/vecmath/point.rs
@@ -31,9 +31,9 @@ pub trait Point2:
     type ElementType: TupleElement;
     type AssociatedVectorType: Vector2 + From<Self>;
 
-    fn distance(&self, p: &Self) -> Float;
+    fn distance(&self, p: Self) -> Float;
 
-    fn distance_squared(&self, p: &Self) -> Float;
+    fn distance_squared(&self, p: Self) -> Float;
 }
 
 pub trait Point3:
@@ -52,9 +52,9 @@ pub trait Point3:
     type ElementType: TupleElement;
     type AssociatedVectorType: Vector3 + From<Self>;
 
-    fn distance(&self, p: &Self) -> Self::ElementType;
+    fn distance(&self, p: Self) -> Self::ElementType;
 
-    fn distance_squared(&self, p: &Self) -> Self::ElementType;
+    fn distance_squared(&self, p: Self) -> Self::ElementType;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,10 +102,10 @@ impl Tuple2<i32> for Point2i {
         self.y
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         Point2i {
-            x: math::lerp(t, &(a.x as Float), &(b.x as Float)) as i32,
-            y: math::lerp(t, &(a.y as Float), &(b.y as Float)) as i32,
+            x: math::lerp(t, a.x as Float, b.x as Float) as i32,
+            y: math::lerp(t, a.y as Float, b.y as Float) as i32,
         }
     }
 
@@ -130,12 +130,12 @@ impl Point2 for Point2i {
     type ElementType = i32;
     type AssociatedVectorType = Vector2i;
 
-    fn distance(&self, p: &Self) -> Float {
+    fn distance(&self, p: Self) -> Float {
         debug_assert!(!self.has_nan());
         (self - p).length() as Float
     }
 
-    fn distance_squared(&self, p: &Self) -> Float {
+    fn distance_squared(&self, p: Self) -> Float {
         debug_assert!(!self.has_nan());
         (self - p).length_squared() as Float
     }
@@ -351,11 +351,11 @@ impl Tuple3<i32> for Point3i {
         self.z
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         Point3i {
-            x: math::lerp(t, &(a.x as Float), &(b.x as Float)) as i32,
-            y: math::lerp(t, &(a.y as Float), &(b.y as Float)) as i32,
-            z: math::lerp(t, &(a.z as Float), &(b.z as Float)) as i32,
+            x: math::lerp(t, a.x as Float, b.x as Float) as i32,
+            y: math::lerp(t, a.y as Float, b.y as Float) as i32,
+            z: math::lerp(t, a.z as Float, b.z as Float) as i32,
         }
     }
 
@@ -388,11 +388,11 @@ impl Point3 for Point3i {
     type ElementType = i32;
     type AssociatedVectorType = Vector3i;
 
-    fn distance(&self, p: &Self) -> i32 {
+    fn distance(&self, p: Self) -> i32 {
         (self - p).length()
     }
 
-    fn distance_squared(&self, p: &Self) -> i32 {
+    fn distance_squared(&self, p: Self) -> i32 {
         (self - p).length_squared()
     }
 }
@@ -593,10 +593,10 @@ impl Tuple2<Float> for Point2f {
         self.y
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         Point2f {
-            x: lerp(t, &a.x, &b.x),
-            y: lerp(t, &a.y, &b.y),
+            x: lerp(t, a.x, b.x),
+            y: lerp(t, a.y, b.y),
         }
     }
 
@@ -621,12 +621,12 @@ impl Point2 for Point2f {
     type ElementType = Float;
     type AssociatedVectorType = Vector2f;
 
-    fn distance(&self, p: &Point2f) -> Float {
+    fn distance(&self, p: Point2f) -> Float {
         debug_assert!(!self.has_nan());
         (self - p).length()
     }
 
-    fn distance_squared(&self, p: &Point2f) -> Float {
+    fn distance_squared(&self, p: Point2f) -> Float {
         debug_assert!(!self.has_nan());
         (self - p).length_squared()
     }
@@ -648,7 +648,7 @@ impl IndexMut<usize> for Point2f {
 
 impl HasNan for Point2f {
     fn has_nan(&self) -> bool {
-        has_nan2(self)
+        has_nan2(*self)
     }
 }
 
@@ -834,11 +834,11 @@ impl Tuple3<Float> for Point3f {
         self.z
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         Self {
-            x: math::lerp(t, &a.x, &b.x),
-            y: math::lerp(t, &a.y, &b.y),
-            z: math::lerp(t, &a.z, &b.z),
+            x: math::lerp(t, a.x, b.x),
+            y: math::lerp(t, a.y, b.y),
+            z: math::lerp(t, a.z, b.z),
         }
     }
 
@@ -871,12 +871,12 @@ impl Point3 for Point3f {
     type ElementType = Float;
     type AssociatedVectorType = Vector3f;
 
-    fn distance(&self, p: &Point3f) -> Float {
+    fn distance(&self, p: Point3f) -> Float {
         debug_assert!(!self.has_nan());
         (self - p).length()
     }
 
-    fn distance_squared(&self, p: &Point3f) -> Float {
+    fn distance_squared(&self, p: Point3f) -> Float {
         debug_assert!(!self.has_nan());
         (self - p).length_squared()
     }
@@ -898,7 +898,7 @@ impl IndexMut<usize> for Point3f {
 
 impl HasNan for Point3f {
     fn has_nan(&self) -> bool {
-        has_nan3(self)
+        has_nan3(*self)
     }
 }
 
@@ -1066,11 +1066,11 @@ impl Tuple3<Interval> for Point3fi {
         &mut self.z
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         Point3fi {
-            x: lerp(t, &a.x, &b.x),
-            y: lerp(t, &a.y, &b.y),
-            z: lerp(t, &a.z, &b.z),
+            x: lerp(t, a.x, b.x),
+            y: lerp(t, a.y, b.y),
+            z: lerp(t, a.z, b.z),
         }
     }
 }
@@ -1084,12 +1084,12 @@ impl Point3 for Point3fi {
 
     type AssociatedVectorType = Vector3fi;
 
-    fn distance(&self, p: &Self) -> Self::ElementType {
+    fn distance(&self, p: Self) -> Self::ElementType {
         debug_assert!(!self.has_nan());
         (self - p).length()
     }
 
-    fn distance_squared(&self, p: &Self) -> Self::ElementType {
+    fn distance_squared(&self, p: Self) -> Self::ElementType {
         debug_assert!(!self.has_nan());
         (self - p).length_squared()
     }
@@ -1225,14 +1225,14 @@ mod tests {
     fn point_point_distance() {
         let p1 = Point2f::new(0.0, 0.0);
         let p2 = Point2f::new(3.0, 4.0);
-        assert_eq!(5.0, p1.distance(&p2));
+        assert_eq!(5.0, p1.distance(p2));
     }
 
     #[test]
     fn point_point_distance_squared() {
         let p1 = Point2f::new(0.0, 0.0);
         let p2 = Point2f::new(3.0, 4.0);
-        assert_eq!(25.0, p1.distance_squared(&p2));
+        assert_eq!(25.0, p1.distance_squared(p2));
     }
 
     #[test]
@@ -1448,7 +1448,7 @@ mod tests {
     fn point2i_lerp() {
         let p1 = Point2i::new(0, 10);
         let p2 = Point2i::new(10, 20);
-        assert_eq!(Point2i::new(5, 15), Point2i::lerp(0.5, &p1, &p2));
+        assert_eq!(Point2i::new(5, 15), Point2i::lerp(0.5, p1, p2));
     }
 
     #[test]
@@ -1462,8 +1462,8 @@ mod tests {
     fn point2i_distance() {
         let p1 = Point2i::ZERO;
         let p2 = Point2i::new(3, 4);
-        assert_eq!(5.0, p1.distance(&p2));
-        assert_eq!(25.0, p1.distance_squared(&p2));
+        assert_eq!(5.0, p1.distance(p2));
+        assert_eq!(25.0, p1.distance_squared(p2));
     }
 
     #[test]
@@ -1508,7 +1508,7 @@ mod tests {
     fn point3f_lerp() {
         let p1 = Point3f::new(0.0, 100.0, 1000.0);
         let p2 = Point3f::new(10.0, 200.0, 2000.0);
-        let p3 = Point3f::lerp(0.5, &p1, &p2);
+        let p3 = Point3f::lerp(0.5, p1, p2);
         assert_eq!(5.0, p3[0]);
         assert_eq!(150.0, p3[1]);
         assert_eq!(1500.0, p3[2]);

--- a/src/vecmath/spherical.rs
+++ b/src/vecmath/spherical.rs
@@ -3,7 +3,7 @@ use crate::{float::PI_F, math::safe_acos, Float};
 use super::{vector::Vector3, Tuple3, Vector3f};
 
 pub fn spherical_triangle_area(a: Vector3f, b: Vector3f, c: Vector3f) -> Float {
-    Float::abs(2.0 * Float::atan2(a.dot(&b.cross(&c)), 1.0 + a.dot(&b) + a.dot(&c) + b.dot(&c)))
+    Float::abs(2.0 * Float::atan2(a.dot(b.cross(c)), 1.0 + a.dot(b) + a.dot(c) + b.dot(c)))
 }
 pub fn spherical_direction(sin_theta: Float, cos_theta: Float, phi: Float) -> Vector3f {
     Vector3f::new(

--- a/src/vecmath/tuple.rs
+++ b/src/vecmath/tuple.rs
@@ -136,10 +136,10 @@ where
     // which do implement Add<Self>. Though you could make an argument that Points should
     // not be able to be lerp'd if they can't be summed, but it's useful to be able to
     // interpolate points even if we typically can't want to allow summing them.
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self;
+    fn lerp(t: Float, a: Self, b: Self) -> Self;
 
     // Take the componentwise minimum of the two tuples.
-    fn min(a: &Self, b: &Self) -> Self {
+    fn min(a: Self, b: Self) -> Self {
         Self::new(
             T::min(a.x(), b.x()),
             T::min(a.y(), b.y()),
@@ -148,7 +148,7 @@ where
     }
 
     // Take the componentwise minimum of the two tuples.
-    fn max(a: &Self, b: &Self) -> Self {
+    fn max(a: Self, b: Self) -> Self {
         Self::new(
             T::max(a.x(), b.x()),
             T::max(a.y(), b.y()),
@@ -285,15 +285,15 @@ where
         Self::new(self.x().floor(), self.y().floor())
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self;
+    fn lerp(t: Float, a: Self, b: Self) -> Self;
 
     // Take the componentwise minimum of the two tuples.
-    fn min(a: &Self, b: &Self) -> Self {
+    fn min(a: Self, b: Self) -> Self {
         Self::new(T::min(a.x(), b.x()), T::min(a.y(), b.y()))
     }
 
     // Take the componentwise maximum of the two tuples.
-    fn max(a: &Self, b: &Self) -> Self {
+    fn max(a: Self, b: Self) -> Self {
         Self::new(T::max(a.x(), b.x()), T::max(a.y(), b.y()))
     }
 

--- a/src/vecmath/tuple_fns.rs
+++ b/src/vecmath/tuple_fns.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::{tuple::TupleElement, Length, Tuple2, Tuple3};
 
-pub fn has_nan3<V, T>(v: &V) -> bool
+pub fn has_nan3<V, T>(v: V) -> bool
 where
     V: Tuple3<T>,
     T: TupleElement,
@@ -19,7 +19,7 @@ where
     v.x().is_nan() || v.y().is_nan() || v.z().is_nan()
 }
 
-pub fn has_nan2<V, T>(v: &V) -> bool
+pub fn has_nan2<V, T>(v: V) -> bool
 where
     V: Tuple2<T>,
     T: TupleElement,
@@ -37,7 +37,7 @@ where
 /// V1: A vector (e.g. Vector3f or a Normal3f).
 /// V2: A vector (e.g. Vector3f or a Normal3f).
 /// V3: The type of the output cross product.
-pub fn cross<V1, V2, V3, E>(v1: &V1, v2: &V2) -> V3
+pub fn cross<V1, V2, V3, E>(v1: V1, v2: V2) -> V3
 where
     V1: Tuple3<E>,
     V2: Tuple3<E>,
@@ -51,7 +51,7 @@ where
     )
 }
 
-pub fn cross_i32<V1, V2, V3>(v1: &V1, v2: &V2) -> V3
+pub fn cross_i32<V1, V2, V3>(v1: V1, v2: V2) -> V3
 where
     V1: Tuple3<i32>,
     V2: Tuple3<i32>,
@@ -65,7 +65,7 @@ where
 }
 
 /// Take the dot product of two vectors.
-pub fn dot3<V1, V2, E>(v: &V1, w: &V2) -> E
+pub fn dot3<V1, V2, E>(v: V1, w: V2) -> E
 where
     V1: Tuple3<E>,
     V2: Tuple3<E>,
@@ -78,7 +78,7 @@ where
 }
 
 /// Take the dot product of two vectors.
-pub fn dot3i<V1, V2>(v: &V1, w: &V2) -> i32
+pub fn dot3i<V1, V2>(v: V1, w: V2) -> i32
 where
     V1: Tuple3<i32>,
     V2: Tuple3<i32>,
@@ -90,7 +90,7 @@ where
 }
 
 /// Take the dot product of two vectors then take the absolute value.
-pub fn abs_dot3<V1, V2, E>(v: &V1, w: &V2) -> E
+pub fn abs_dot3<V1, V2, E>(v: V1, w: V2) -> E
 where
     V1: Tuple3<E>,
     V2: Tuple3<E>,
@@ -100,7 +100,7 @@ where
 }
 
 /// Take the dot product of two vectors then take the absolute value.
-pub fn abs_dot3i<V1, V2>(v: &V1, w: &V2) -> i32
+pub fn abs_dot3i<V1, V2>(v: V1, w: V2) -> i32
 where
     V1: Tuple3<i32>,
     V2: Tuple3<i32>,
@@ -109,7 +109,7 @@ where
 }
 
 /// Take the dot product of two vectors.
-pub fn dot2<V1, V2>(v: &V1, w: &V2) -> Float
+pub fn dot2<V1, V2>(v: V1, w: V2) -> Float
 where
     V1: Tuple2<Float>,
     V2: Tuple2<Float>,
@@ -120,7 +120,7 @@ where
 }
 
 /// Take the dot product of two vectors.
-pub fn dot2i<V1, V2>(v: &V1, w: &V2) -> i32
+pub fn dot2i<V1, V2>(v: V1, w: V2) -> i32
 where
     V1: Tuple2<i32>,
     V2: Tuple2<i32>,
@@ -131,7 +131,7 @@ where
 }
 
 /// Take the dot product of two vectors then take the absolute value.
-pub fn abs_dot2<V1, V2>(v: &V1, w: &V2) -> Float
+pub fn abs_dot2<V1, V2>(v: V1, w: V2) -> Float
 where
     V1: Tuple2<Float>,
     V2: Tuple2<Float>,
@@ -140,7 +140,7 @@ where
 }
 
 /// Take the dot product of two vectors then take the absolute value.
-pub fn abs_dot2i<V1, V2>(v: &V1, w: &V2) -> i32
+pub fn abs_dot2i<V1, V2>(v: V1, w: V2) -> i32
 where
     V1: Tuple2<i32>,
     V2: Tuple2<i32>,
@@ -159,13 +159,13 @@ where
 /// V3: The resulting type from adding or subtracting V1 and V2.
 ///   That is typically a Vector3f.
 ///   We just use the third type to be able to specify that that is the case.
-pub fn angle_between<'a, V1, V2, V3, E>(v1: &'a V1, v2: &'a V2) -> Float
+pub fn angle_between<V1, V2, V3, E>(v1: V1, v2: V2) -> Float
 where
     V1: Tuple3<E>,
     V2: Tuple3<E>,
     V3: Tuple3<E> + Length<E>,
-    &'a V1: Add<&'a V2, Output = V3>,
-    &'a V2: Add<&'a V1, Output = V3> + Sub<&'a V1, Output = V3>,
+    V1: Add<V2, Output = V3>,
+    V2: Add<V1, Output = V3> + Sub<V1, Output = V3>,
     E: TupleElement + MulAdd + DifferenceOfProducts + Into<Float>,
 {
     // TODO This function could also report an Interval for interval types e.g. two Vector3fi.
@@ -182,13 +182,13 @@ where
     }
 }
 
-pub fn angle_between2<'a, V1, V2, V3>(v1: &'a V1, v2: &'a V2) -> Float
+pub fn angle_between2<V1, V2, V3>(v1: V1, v2: V2) -> Float
 where
     V1: Tuple2<Float>,
     V2: Tuple2<Float>,
     V3: Tuple2<Float> + Length<Float>,
-    &'a V1: Add<&'a V2, Output = V3>,
-    &'a V2: Add<&'a V1, Output = V3> + Sub<&'a V1, Output = V3>,
+    V1: Add<V2, Output = V3>,
+    V2: Add<V1, Output = V3> + Sub<V1, Output = V3>,
 {
     debug_assert!(!v1.has_nan());
     debug_assert!(!v2.has_nan());
@@ -199,15 +199,15 @@ where
     }
 }
 
-pub fn face_forward<T1, T2, E>(a: &T1, b: &T2) -> T1
+pub fn face_forward<T1, T2, E>(a: T1, b: T2) -> T1
 where
     T1: Tuple3<E> + Neg<Output = T1>,
     T2: Tuple3<E>,
     E: TupleElement + MulAdd + DifferenceOfProducts + IsNeg,
 {
     if dot3(a, b).is_neg() {
-        -*a
+        -a
     } else {
-        *a
+        a
     }
 }

--- a/src/vecmath/vector.rs
+++ b/src/vecmath/vector.rs
@@ -39,19 +39,19 @@ pub trait Vector2:
     type ElementType: TupleElement;
 
     /// Compute the dot product.
-    fn dot(&self, v: &Self) -> Self::ElementType;
+    fn dot(&self, v: Self) -> Self::ElementType;
 
     /// Compute the dot product and take the absolute value.
-    fn abs_dot(&self, v: &Self) -> Self::ElementType;
+    fn abs_dot(&self, v: Self) -> Self::ElementType;
 
     /// Find the andle between this vector and another vector.
     /// Both vectors must be normalized.
-    fn angle_between(&self, v: &Self) -> Float;
+    fn angle_between(&self, v: Self) -> Float;
 
     /// Create a new vector orthogonal to w.
     /// w must be normalized.
     /// See PBRTv4 3.2
-    fn gram_schmidt(&self, w: &Self) -> Self;
+    fn gram_schmidt(&self, w: Self) -> Self;
 }
 
 pub trait Vector3:
@@ -74,43 +74,43 @@ pub trait Vector3:
     type AssociatedNormalType: Normal3;
 
     /// Compute the dot product.
-    fn dot(&self, v: &Self) -> Self::ElementType;
+    fn dot(&self, v: Self) -> Self::ElementType;
 
     /// Dot this vector with a normal.
-    fn dot_normal(&self, n: &Self::AssociatedNormalType) -> Self::ElementType;
+    fn dot_normal(&self, n: Self::AssociatedNormalType) -> Self::ElementType;
 
     /// Compute the dot product and take the absolute value.
-    fn abs_dot(&self, v: &Self) -> Self::ElementType;
+    fn abs_dot(&self, v: Self) -> Self::ElementType;
 
     /// Dot this vector with a normal and take its absolute value.
-    fn abs_dot_normal(&self, n: &Self::AssociatedNormalType) -> Self::ElementType;
+    fn abs_dot_normal(&self, n: Self::AssociatedNormalType) -> Self::ElementType;
 
     /// Take the cross product of this and a vector v.
     /// Uses an EFT method for calculating the value with minimal error without
     /// casting to f64. See PBRTv4 3.3.2.
-    fn cross(&self, v: &Self) -> Self;
+    fn cross(&self, v: Self) -> Self;
 
     /// Take the cross product of this and a normal n.
     /// Uses an EFT method for calculating the value with minimal error without
     /// casting to f64. See PBRTv4 3.3.2.
-    fn cross_normal(&self, n: &Self::AssociatedNormalType) -> Self;
+    fn cross_normal(&self, n: Self::AssociatedNormalType) -> Self;
 
     /// Find the andle between this vector and another vector.
     /// Both vectors must be normalized.
-    fn angle_between(&self, v: &Self) -> Float;
+    fn angle_between(&self, v: Self) -> Float;
 
     /// Find the angle between this vector and a normal
     /// Both vectors must be normalized.
-    fn angle_between_normal(&self, n: &Self::AssociatedNormalType) -> Float;
+    fn angle_between_normal(&self, n: Self::AssociatedNormalType) -> Float;
 
     /// Create a new vector orthogonal to w.
     /// w must be normalized.
     /// See PBRTv4 3.2
-    fn gram_schmidt(&self, w: &Self) -> Self;
+    fn gram_schmidt(&self, w: Self) -> Self;
 
-    fn face_forward(&self, v2: &Self) -> Self;
+    fn face_forward(&self, v2: Self) -> Self;
 
-    fn face_forward_n(&self, n: &Self::AssociatedNormalType) -> Self;
+    fn face_forward_n(&self, n: Self::AssociatedNormalType) -> Self;
 }
 
 // ---------------------------------------------------------------------------
@@ -159,7 +159,7 @@ impl Tuple2<i32> for Vector2i {
         self.y
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         lerp(t, a, b)
     }
 
@@ -184,23 +184,23 @@ impl Vector2 for Vector2i {
     type ElementType = i32;
 
     /// Compute the dot product.
-    fn dot(&self, v: &Self) -> i32 {
-        dot2i(self, v)
+    fn dot(&self, v: Self) -> i32 {
+        dot2i(*self, v)
     }
 
     /// Compute the dot product and take the absolute value.
-    fn abs_dot(&self, v: &Self) -> i32 {
-        abs_dot2i(self, v)
+    fn abs_dot(&self, v: Self) -> i32 {
+        abs_dot2i(*self, v)
     }
 
-    fn angle_between(&self, v: &Self) -> Float {
-        angle_between2(&Vector2f::from(self), &Vector2f::from(v))
+    fn angle_between(&self, v: Self) -> Float {
+        angle_between2(Vector2f::from(self), Vector2f::from(v))
     }
 
     /// Create a new vector orthogonal to w.
     /// w must be normalized.
     /// See PBRTv4 3.2
-    fn gram_schmidt(&self, w: &Self) -> Self {
+    fn gram_schmidt(&self, w: Self) -> Self {
         self - self.dot(w) * w
     }
 }
@@ -436,7 +436,7 @@ impl Tuple3<i32> for Vector3i {
         self.z
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         lerp(t, a, b)
     }
 
@@ -470,60 +470,60 @@ impl Vector3 for Vector3i {
     type AssociatedNormalType = Normal3i;
 
     /// Compute the dot product
-    fn dot(&self, v: &Self) -> i32 {
-        dot3i(self, v)
+    fn dot(&self, v: Self) -> i32 {
+        dot3i(*self, v)
     }
 
     /// Dot this vector with a normal.
-    fn dot_normal(&self, n: &Normal3i) -> i32 {
-        dot3i(self, n)
+    fn dot_normal(&self, n: Normal3i) -> i32 {
+        dot3i(*self, n)
     }
 
     /// Compute the dot product and take the absolute value.
-    fn abs_dot(&self, v: &Self) -> i32 {
-        abs_dot3i(self, v)
+    fn abs_dot(&self, v: Self) -> i32 {
+        abs_dot3i(*self, v)
     }
 
     /// Dot this vector with a normal and take the absolute value.
-    fn abs_dot_normal(&self, n: &Normal3i) -> i32 {
-        abs_dot3i(self, n)
+    fn abs_dot_normal(&self, n: Normal3i) -> i32 {
+        abs_dot3i(*self, n)
     }
 
     /// Take the cross product of this and a vector v
-    fn cross(&self, v: &Self) -> Self {
+    fn cross(&self, v: Self) -> Self {
         // Integer vectors do not need to use EFT methods for accuracy.
-        cross_i32(self, v)
+        cross_i32(*self, v)
     }
 
     /// Take the cross product of this and a normal n
-    fn cross_normal(&self, n: &Normal3i) -> Self {
-        cross_i32(self, n)
+    fn cross_normal(&self, n: Normal3i) -> Self {
+        cross_i32(*self, n)
     }
 
-    fn angle_between(&self, v: &Self) -> Float {
-        angle_between(&Vector3f::from(self), &Vector3f::from(v))
+    fn angle_between(&self, v: Self) -> Float {
+        angle_between(Vector3f::from(self), Vector3f::from(v))
     }
 
-    fn angle_between_normal(&self, n: &Self::AssociatedNormalType) -> Float {
+    fn angle_between_normal(&self, n: Self::AssociatedNormalType) -> Float {
         angle_between::<Vector3f, Normal3f, Vector3f, Float>(
-            &Vector3f::from(self),
-            &Normal3f::from(n),
+            Vector3f::from(self),
+            Normal3f::from(n),
         )
     }
 
     /// Create a new vector orthogonal to w.
     /// w must be normalized.
     /// See PBRTv4 3.2
-    fn gram_schmidt(&self, w: &Self) -> Self {
+    fn gram_schmidt(&self, w: Self) -> Self {
         self - self.dot(w) * w
     }
 
-    fn face_forward(&self, v2: &Self) -> Self {
-        face_forward(self, v2)
+    fn face_forward(&self, v2: Self) -> Self {
+        face_forward(*self, v2)
     }
 
-    fn face_forward_n(&self, n: &Self::AssociatedNormalType) -> Self {
-        face_forward(self, n)
+    fn face_forward_n(&self, n: Self::AssociatedNormalType) -> Self {
+        face_forward(*self, n)
     }
 }
 
@@ -764,7 +764,7 @@ impl Tuple2<Float> for Vector2f {
         self.y
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         lerp(t, a, b)
     }
 
@@ -789,23 +789,23 @@ impl Vector2 for Vector2f {
     type ElementType = Float;
 
     /// Compute the dot product.
-    fn dot(&self, v: &Self) -> Float {
-        dot2(self, v)
+    fn dot(&self, v: Self) -> Float {
+        dot2(*self, v)
     }
 
     /// Compute the dot product and take the absolute value.
-    fn abs_dot(&self, v: &Self) -> Float {
-        abs_dot2(self, v)
+    fn abs_dot(&self, v: Self) -> Float {
+        abs_dot2(*self, v)
     }
 
-    fn angle_between(&self, v: &Self) -> Float {
-        angle_between2(self, v)
+    fn angle_between(&self, v: Self) -> Float {
+        angle_between2(*self, v)
     }
 
     /// Create a new vector orthogonal to w.
     /// w must be normalized.
     /// See PBRTv4 3.2
-    fn gram_schmidt(&self, w: &Self) -> Self {
+    fn gram_schmidt(&self, w: Self) -> Self {
         self - self.dot(w) * w
     }
 }
@@ -826,7 +826,7 @@ impl IndexMut<usize> for Vector2f {
 
 impl HasNan for Vector2f {
     fn has_nan(&self) -> bool {
-        has_nan2(self)
+        has_nan2(*self)
     }
 }
 
@@ -925,6 +925,15 @@ impl From<(Float, Float)> for Vector2f {
 impl From<Vector2f> for (Float, Float) {
     fn from(value: Vector2f) -> Self {
         (value.x, value.y)
+    }
+}
+
+impl From<Vector2i> for Vector2f {
+    fn from(value: Vector2i) -> Self {
+        Vector2f {
+            x: value.x as Float,
+            y: value.y as Float,
+        }
     }
 }
 
@@ -1050,7 +1059,7 @@ impl Tuple3<Float> for Vector3f {
         self.z
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         lerp(t, a, b)
     }
 
@@ -1084,64 +1093,64 @@ impl Vector3 for Vector3f {
     type AssociatedNormalType = Normal3f;
 
     /// Compute the dot product.
-    fn dot(&self, v: &Self) -> Float {
-        dot3(self, v)
+    fn dot(&self, v: Self) -> Float {
+        dot3(*self, v)
     }
 
     /// Dot this vector with a normal.
-    fn dot_normal(&self, n: &Normal3f) -> Float {
-        dot3(self, n)
+    fn dot_normal(&self, n: Normal3f) -> Float {
+        dot3(*self, n)
     }
 
     /// Compute the dot product and take the absolute value.
-    fn abs_dot(&self, v: &Self) -> Float {
-        abs_dot3(self, v)
+    fn abs_dot(&self, v: Self) -> Float {
+        abs_dot3(*self, v)
     }
 
     /// Dot this vector with a normal and take its absolute value.
-    fn abs_dot_normal(&self, n: &Normal3f) -> Float {
-        abs_dot3(self, n)
+    fn abs_dot_normal(&self, n: Normal3f) -> Float {
+        abs_dot3(*self, n)
     }
 
     /// Take the cross product of this and a vector v.
     /// Uses an EFT method for calculating the value with minimal error without
     /// casting to f64. See PBRTv4 3.3.2.
-    fn cross(&self, v: &Self) -> Self {
-        cross::<Vector3f, Vector3f, Vector3f, Float>(self, v)
+    fn cross(&self, v: Self) -> Self {
+        cross::<Vector3f, Vector3f, Vector3f, Float>(*self, v)
     }
 
     /// Take the cross product of this and a normal n.
     /// Uses an EFT method for calculating the value with minimal error without
     /// casting to f64. See PBRTv4 3.3.2.
-    fn cross_normal(&self, n: &Normal3f) -> Self {
-        cross::<Vector3f, Normal3f, Vector3f, Float>(self, n)
+    fn cross_normal(&self, n: Normal3f) -> Self {
+        cross::<Vector3f, Normal3f, Vector3f, Float>(*self, n)
     }
 
     /// Find the andle between this vector and another vector.
     /// Both vectors must be normalized.
-    fn angle_between(&self, v: &Self) -> Float {
-        angle_between(self, v)
+    fn angle_between(&self, v: Self) -> Float {
+        angle_between(*self, v)
     }
 
     /// Find the angle between this vector and a normal
     /// Both vectors must be normalized.
-    fn angle_between_normal(&self, n: &Normal3f) -> Float {
-        angle_between::<Vector3f, Normal3f, Vector3f, Float>(self, n)
+    fn angle_between_normal(&self, n: Normal3f) -> Float {
+        angle_between::<Vector3f, Normal3f, Vector3f, Float>(*self, n)
     }
 
     /// Create a new vector orthogonal to w.
     /// w must be normalized.
     /// See PBRTv4 3.2
-    fn gram_schmidt(&self, w: &Self) -> Self {
+    fn gram_schmidt(&self, w: Self) -> Self {
         self - self.dot(w) * w
     }
 
-    fn face_forward(&self, v2: &Self) -> Self {
-        face_forward(self, v2)
+    fn face_forward(&self, v2: Self) -> Self {
+        face_forward(*self, v2)
     }
 
-    fn face_forward_n(&self, n: &Self::AssociatedNormalType) -> Self {
-        face_forward(self, n)
+    fn face_forward_n(&self, n: Self::AssociatedNormalType) -> Self {
+        face_forward(*self, n)
     }
 }
 
@@ -1161,7 +1170,7 @@ impl IndexMut<usize> for Vector3f {
 
 impl HasNan for Vector3f {
     fn has_nan(&self) -> bool {
-        has_nan3(self)
+        has_nan3(*self)
     }
 }
 
@@ -1284,6 +1293,12 @@ impl From<&Vector3i> for Vector3f {
     }
 }
 
+impl From<Vector3i> for Vector3f {
+    fn from(value: Vector3i) -> Self {
+        Self::new(value.x as Float, value.y as Float, value.z as Float)
+    }
+}
+
 impl From<Vector3fi> for Vector3f {
     fn from(value: Vector3fi) -> Self {
         Vector3f {
@@ -1364,11 +1379,11 @@ impl Tuple3<Interval> for Vector3fi {
         &mut self.z
     }
 
-    fn lerp(t: Float, a: &Self, b: &Self) -> Self {
+    fn lerp(t: Float, a: Self, b: Self) -> Self {
         Self {
-            x: lerp(t, &a.x, &b.x),
-            y: lerp(t, &a.y, &b.y),
-            z: lerp(t, &a.z, &b.z),
+            x: lerp(t, a.x, b.x),
+            y: lerp(t, a.y, b.y),
+            z: lerp(t, a.z, b.z),
         }
     }
 }
@@ -1378,50 +1393,50 @@ impl Vector3 for Vector3fi {
 
     type AssociatedNormalType = Normal3fi;
 
-    fn dot(&self, v: &Self) -> Self::ElementType {
-        dot3(self, v)
+    fn dot(&self, v: Self) -> Self::ElementType {
+        dot3(*self, v)
     }
 
-    fn dot_normal(&self, n: &Self::AssociatedNormalType) -> Self::ElementType {
-        dot3(self, n)
+    fn dot_normal(&self, n: Self::AssociatedNormalType) -> Self::ElementType {
+        dot3(*self, n)
     }
 
-    fn abs_dot(&self, v: &Self) -> Self::ElementType {
-        abs_dot3(self, v)
+    fn abs_dot(&self, v: Self) -> Self::ElementType {
+        abs_dot3(*self, v)
     }
 
-    fn abs_dot_normal(&self, n: &Self::AssociatedNormalType) -> Self::ElementType {
-        abs_dot3(self, n)
+    fn abs_dot_normal(&self, n: Self::AssociatedNormalType) -> Self::ElementType {
+        abs_dot3(*self, n)
     }
 
-    fn cross(&self, v: &Self) -> Self {
-        cross::<Vector3fi, Vector3fi, Vector3fi, Interval>(self, v)
+    fn cross(&self, v: Self) -> Self {
+        cross::<Vector3fi, Vector3fi, Vector3fi, Interval>(*self, v)
     }
 
-    fn cross_normal(&self, n: &Self::AssociatedNormalType) -> Self {
-        cross::<Vector3fi, Normal3fi, Vector3fi, Interval>(self, n)
+    fn cross_normal(&self, n: Self::AssociatedNormalType) -> Self {
+        cross::<Vector3fi, Normal3fi, Vector3fi, Interval>(*self, n)
     }
 
-    fn angle_between(&self, v: &Self) -> Float {
-        angle_between::<Vector3fi, Vector3fi, Vector3fi, Interval>(self, v)
+    fn angle_between(&self, v: Self) -> Float {
+        angle_between::<Vector3fi, Vector3fi, Vector3fi, Interval>(*self, v)
     }
 
-    fn angle_between_normal(&self, n: &Self::AssociatedNormalType) -> Float {
-        angle_between::<Vector3fi, Normal3fi, Vector3fi, Interval>(self, n)
+    fn angle_between_normal(&self, n: Self::AssociatedNormalType) -> Float {
+        angle_between::<Vector3fi, Normal3fi, Vector3fi, Interval>(*self, n)
     }
 
-    fn gram_schmidt(&self, w: &Self) -> Self {
+    fn gram_schmidt(&self, w: Self) -> Self {
         // TODO should make a generic version. It should cover both Vector2 and Vector3.
         // Can do that when we rework this whole module, though.
         self - self.dot(w) * w
     }
 
-    fn face_forward(&self, v2: &Self) -> Self {
-        face_forward(self, v2)
+    fn face_forward(&self, v2: Self) -> Self {
+        face_forward(*self, v2)
     }
 
-    fn face_forward_n(&self, n: &Self::AssociatedNormalType) -> Self {
-        face_forward(self, n)
+    fn face_forward_n(&self, n: Self::AssociatedNormalType) -> Self {
+        face_forward(*self, n)
     }
 }
 
@@ -1613,82 +1628,82 @@ mod tests {
     fn vector_vector_dot() {
         let v1 = Vector3f::new(0.0, 1.0, 2.0);
         let v2 = Vector3f::new(3.0, 4.0, 5.0);
-        assert_eq!(14.0, v1.dot(&v2));
+        assert_eq!(14.0, v1.dot(v2));
 
         let v1 = Vector3i::new(0, 1, 2);
         let v2 = Vector3i::new(3, 4, 5);
-        assert_eq!(14, v1.dot(&v2));
+        assert_eq!(14, v1.dot(v2));
 
         let v1 = Vector2f::new(0.0, 1.0);
         let v2 = Vector2f::new(2.0, 3.0);
-        assert_eq!(3.0, v1.dot(&v2));
+        assert_eq!(3.0, v1.dot(v2));
 
         let v1 = Vector2i::new(0, 1);
         let v2 = Vector2i::new(2, 3);
-        assert_eq!(3, v1.dot(&v2));
+        assert_eq!(3, v1.dot(v2));
     }
 
     #[test]
     fn vector_normal_dot() {
         let v1 = Vector3f::new(0.0, 1.0, 2.0);
         let n = Normal3f::new(3.0, 4.0, 5.0);
-        assert_eq!(14.0, v1.dot_normal(&n));
+        assert_eq!(14.0, v1.dot_normal(n));
 
         let v1 = Vector3i::new(0, 1, 2);
         let n = Normal3i::new(3, 4, 5);
-        assert_eq!(14, v1.dot_normal(&n));
+        assert_eq!(14, v1.dot_normal(n));
     }
 
     #[test]
     fn vector_vector_abs_dot() {
         let v1 = Vector3f::new(0.0, 1.0, 2.0);
         let v2 = -Vector3f::new(3.0, 4.0, 5.0);
-        assert_eq!(14.0, v1.abs_dot(&v2));
+        assert_eq!(14.0, v1.abs_dot(v2));
 
         let v1 = Vector3i::new(0, 1, 2);
         let v2 = -Vector3i::new(3, 4, 5);
-        assert_eq!(14, v1.abs_dot(&v2));
+        assert_eq!(14, v1.abs_dot(v2));
 
         let v1 = Vector2f::new(0.0, 1.0);
         let v2 = -Vector2f::new(2.0, 3.0);
-        assert_eq!(3.0, v1.abs_dot(&v2));
+        assert_eq!(3.0, v1.abs_dot(v2));
 
         let v1 = Vector2i::new(0, 1);
         let v2 = -Vector2i::new(2, 3);
-        assert_eq!(3, v1.abs_dot(&v2));
+        assert_eq!(3, v1.abs_dot(v2));
     }
 
     #[test]
     fn vector_normal_abs_dot() {
         let v1 = Vector3f::new(0.0, 1.0, 2.0);
         let n = -Normal3f::new(3.0, 4.0, 5.0);
-        assert_eq!(14.0, v1.abs_dot_normal(&n));
+        assert_eq!(14.0, v1.abs_dot_normal(n));
 
         let v1 = Vector3i::new(0, 1, 2);
         let n = -Normal3i::new(3, 4, 5);
-        assert_eq!(14, v1.abs_dot_normal(&n));
+        assert_eq!(14, v1.abs_dot_normal(n));
     }
 
     #[test]
     fn vector_vector_cross() {
         let v1 = Vector3i::new(3, -3, 1);
         let v2 = Vector3i::new(4, 9, 2);
-        assert_eq!(Vector3i::new(-15, -2, 39), v1.cross(&v2));
+        assert_eq!(Vector3i::new(-15, -2, 39), v1.cross(v2));
 
         let v1 = Vector3f::new(3.0, -3.0, 1.0);
         let v2 = Vector3f::new(4.0, 9.0, 2.0);
-        assert_eq!(Vector3f::new(-15.0, -2.0, 39.0), v1.cross(&v2));
+        assert_eq!(Vector3f::new(-15.0, -2.0, 39.0), v1.cross(v2));
     }
 
     #[test]
     fn vector_normal_cross() {
         let v1 = Vector3i::new(3, -3, 1);
         let n = Normal3i::new(4, 9, 2);
-        assert_eq!(Vector3i::new(-15, -2, 39), v1.cross_normal(&n));
+        assert_eq!(Vector3i::new(-15, -2, 39), v1.cross_normal(n));
 
         let v1 = Vector3f::new(3.0, -3.0, 1.0);
         let n = Normal3f::new(4.0, 9.0, 2.0);
-        assert_eq!(Vector3f::new(-15.0, -2.0, 39.0), v1.cross_normal(&n));
+        assert_eq!(Vector3f::new(-15.0, -2.0, 39.0), v1.cross_normal(n));
     }
 
     #[test]
@@ -1696,7 +1711,7 @@ mod tests {
         let v1 = Vector3f::new(1.0, 2.0, 3.0).normalize();
         let v2 = Vector3f::new(3.0, 4.0, 5.0).normalize();
 
-        assert_eq!(0.18623877, v1.angle_between(&v2));
+        assert_eq!(0.18623877, v1.angle_between(v2));
     }
 
     #[test]
@@ -1704,7 +1719,7 @@ mod tests {
         let v = Vector3f::new(1.0, 2.0, 3.0).normalize();
         let n = Normal3f::new(3.0, 4.0, 5.0).normalize();
 
-        assert_eq!(0.18623877, v.angle_between_normal(&n));
+        assert_eq!(0.18623877, v.angle_between_normal(n));
     }
 
     #[test]
@@ -1727,7 +1742,7 @@ mod tests {
         let v1 = Vector3f::new(1.0, -1.0, 1.0);
         let v2 = Vector3f::new(1.0, 0.0, 1.0);
 
-        let v2_schmidted = v2.gram_schmidt(&v1.normalize());
+        let v2_schmidted = v2.gram_schmidt(v1.normalize());
 
         let expected_x: Float = 1.0 / 3.0;
         let expected_y: Float = 2.0 / 3.0;
@@ -1787,45 +1802,45 @@ mod tests {
     fn vector_lerp() {
         let v1 = Vector3f::new(0.0, 0.0, 0.0);
         let v2 = Vector3f::new(1.0, 10.0, 100.0);
-        assert_eq!(Vector3f::new(0.5, 5.0, 50.0), Tuple3::lerp(0.5, &v1, &v2))
+        assert_eq!(Vector3f::new(0.5, 5.0, 50.0), Tuple3::lerp(0.5, v1, v2))
     }
 
     #[test]
     fn vector_min() {
         let v1 = Vector3f::new(100.0, 0.0, 0.0);
         let v2 = Vector3f::new(0.0, 10.0, 100.0);
-        assert_eq!(Vector3f::new(0.0, 0.0, 0.0), Tuple3::min(&v1, &v2));
+        assert_eq!(Vector3f::new(0.0, 0.0, 0.0), Tuple3::min(v1, v2));
 
         let v1 = Vector3i::new(100, 0, 0);
         let v2 = Vector3i::new(0, 10, 100);
-        assert_eq!(Vector3i::new(0, 0, 0), Tuple3::min(&v1, &v2));
+        assert_eq!(Vector3i::new(0, 0, 0), Tuple3::min(v1, v2));
 
         let v1 = Vector2f::new(100.0, 0.0);
         let v2 = Vector2f::new(0.0, 10.0);
-        assert_eq!(Vector2f::new(0.0, 0.0), Tuple2::min(&v1, &v2));
+        assert_eq!(Vector2f::new(0.0, 0.0), Tuple2::min(v1, v2));
 
         let v1 = Vector2i::new(100, 0);
         let v2 = Vector2i::new(0, 10);
-        assert_eq!(Vector2i::new(0, 0), Tuple2::min(&v1, &v2));
+        assert_eq!(Vector2i::new(0, 0), Tuple2::min(v1, v2));
     }
 
     #[test]
     fn vector_max() {
         let v1 = Vector3f::new(100.0, 0.0, 0.0);
         let v2 = Vector3f::new(0.0, 10.0, 100.0);
-        assert_eq!(Vector3f::new(100.0, 10.0, 100.0), Tuple3::max(&v1, &v2));
+        assert_eq!(Vector3f::new(100.0, 10.0, 100.0), Tuple3::max(v1, v2));
 
         let v1 = Vector3i::new(100, 0, 0);
         let v2 = Vector3i::new(0, 10, 100);
-        assert_eq!(Vector3i::new(100, 10, 100), Tuple3::max(&v1, &v2));
+        assert_eq!(Vector3i::new(100, 10, 100), Tuple3::max(v1, v2));
 
         let v1 = Vector2f::new(100.0, 0.0);
         let v2 = Vector2f::new(0.0, 10.0);
-        assert_eq!(Vector2f::new(100.0, 10.0), Tuple2::max(&v1, &v2));
+        assert_eq!(Vector2f::new(100.0, 10.0), Tuple2::max(v1, v2));
 
         let v1 = Vector2i::new(100, 0);
         let v2 = Vector2i::new(0, 10);
-        assert_eq!(Vector2i::new(100, 10), Tuple2::max(&v1, &v2));
+        assert_eq!(Vector2i::new(100, 10), Tuple2::max(v1, v2));
     }
 
     #[test]


### PR DESCRIPTION
This doesn't impact performance as the structs are so small, but it does make callsites a bit cleaner.

For generic functions like lerp(), this is also better since you could just implement the trait bounds on &T if you want to pass by reference.