### PR TITLE
Improve BVH construction, vastly improve performance, misc bug fixes

### DIFF
--- a/scenes/killeroos/killeroo-simple-diffuse.pbrt
+++ b/scenes/killeroos/killeroo-simple-diffuse.pbrt
@@ -5,7 +5,7 @@ Rotate -5 0 0 1
 Camera "perspective"
     "float fov" [ 39 ]
 Film "rgb"
-    "string filename" [ "killeroo-simple-diffuse-fixed-ndc-transform.pfm" ]
+    "string filename" [ "killeroo-simple-diffuse-fixed-dxdy.pfm" ]
     "integer yresolution" [ 480 ]
     "integer xresolution" [ 480 ]
 Sampler "independent"

--- a/scenes/killeroos/killeroo-simple-diffuse.pbrt
+++ b/scenes/killeroos/killeroo-simple-diffuse.pbrt
@@ -5,7 +5,7 @@ Rotate -5 0 0 1
 Camera "perspective"
     "float fov" [ 39 ]
 Film "rgb"
-    "string filename" [ "killeroo-simple-diffuse-fixed-bvh.pfm" ]
+    "string filename" [ "killeroo-simple-diffuse-fixed-ndc-transform.pfm" ]
     "integer yresolution" [ 480 ]
     "integer xresolution" [ 480 ]
 Sampler "independent"

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -631,7 +631,7 @@ impl ProjectiveCameraBase {
         ) * Transform::translate(Vector3f::new(
             -screen_window.min.x,
             -screen_window.max.y,
-            1.0,
+            0.0,
         ));
         let raster_from_ndc = Transform::scale(
             camera_base.film.full_resolution().x as Float,

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -919,10 +919,10 @@ impl PerspectiveCamera {
         // their origins are unchanges and the ray differentials differ only in their direction
         // for perspective cameras. Compute the change in position on the near perspective plane
         // in camera space wrt shifts in pixel locations.
-        let dx_camera = projective_base.camera_from_raster.apply(&Vector3f::X)
-            - projective_base.camera_from_raster.apply(&Vector3f::ZERO);
-        let dy_camera = projective_base.camera_from_raster.apply(&Vector3f::Y)
-            - projective_base.camera_from_raster.apply(&Vector3f::ZERO);
+        let dx_camera = projective_base.camera_from_raster.apply(&Point3f::X)
+            - projective_base.camera_from_raster.apply(&Point3f::ZERO);
+        let dy_camera = projective_base.camera_from_raster.apply(&Point3f::Y)
+            - projective_base.camera_from_raster.apply(&Point3f::ZERO);
 
         // Compute cos_total_width for perspective camera, the cosine of the maximum angle of the FOV.
         // This is used in a few places, such as for culling points outside the FOV quickly.


### PR DESCRIPTION
Fixed BVH node bounds calculations, which vastly improves performance. Had used zero as the start for the BVH bounds accumulator; should have used the default, which uses MAX/MIN for the min/max of the bounds respectively, which allows unions to properly accumulate. I fixed this bug in a different spot in a previous commit, but missed it here.

Performance is now on par with PBRTv4.

Also includes some minor bug fixes related to camera construction.