### PR TITLE
Switch Transform trait to be generic

### DIFF
--- a/src/direction_cone.rs
+++ b/src/direction_cone.rs
@@ -2,7 +2,7 @@ use crate::{
     bounding_box::Bounds3f,
     float::PI_F,
     math::{degrees, safe_acos, safe_sqrt},
-    transform::Transform,
+    transform::{Transform, TransformI},
     vecmath::{point::Point3, vector::Vector3, Length, Normalize, Point3f, Vector3f},
     Float,
 };
@@ -102,7 +102,7 @@ impl DirectionCone {
         if wr.length_squared() == 0.0 {
             return DirectionCone::entire_sphere();
         }
-        let w = Transform::rotate(degrees(theta_r), &wr).apply(&self.w);
+        let w = Transform::rotate(degrees(theta_r), &wr).apply(self.w);
         DirectionCone::new(w, Float::cos(theta_o))
     }
 }

--- a/src/light.rs
+++ b/src/light.rs
@@ -14,8 +14,7 @@ use crate::{
     float::PI_F,
     image::Image,
     interaction::{Interaction, SurfaceInteraction},
-    loading::paramdict::ParameterDictionary,
-    loading::parser_target::FileLoc,
+    loading::{paramdict::ParameterDictionary, parser_target::FileLoc},
     media::Medium,
     options::Options,
     ray::Ray,
@@ -28,7 +27,7 @@ use crate::{
         DenselySampledSpectrum, Spectrum,
     },
     texture::FloatTexture,
-    transform::Transform,
+    transform::{Transform, TransformI},
     vecmath::{
         normal::Normal3,
         point::{Point3, Point3fi},
@@ -410,7 +409,7 @@ impl LightI for PointLight {
         lambda: &SampledWavelengths,
         _allow_incomplete_pdf: bool,
     ) -> Option<LightLiSample> {
-        let p = self.base.render_from_light.apply(&Point3f::ZERO);
+        let p = self.base.render_from_light.apply(Point3f::ZERO);
         let wi = (p - ctx.p()).normalize();
         let li = self.scale * self.i.sample(&lambda) / p.distance_squared(ctx.p());
         // TODO I do think this is correct compared to PBRT,

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -7,7 +7,7 @@ use crate::{
     material::Material,
     ray::Ray,
     shape::{Shape, ShapeI, ShapeIntersection},
-    transform::Transform,
+    transform::{InverseTransformRayI, Transform, TransformI, TransformRayI},
     vecmath::normal::Normal3,
     Float,
 };
@@ -153,24 +153,24 @@ impl TransformedPrimitive {
 
 impl PrimitiveI for TransformedPrimitive {
     fn bounds(&self) -> Bounds3f {
-        self.render_from_primitive.apply(&self.primitive.bounds())
+        self.render_from_primitive.apply(self.primitive.bounds())
     }
 
     fn intersect(&self, ray: &Ray, mut t_max: Float) -> Option<ShapeIntersection> {
         let ray = self
             .render_from_primitive
-            .apply_ray_inverse(ray, Some(&mut t_max));
+            .apply_ray_inverse(*ray, Some(&mut t_max));
         let mut si = self.primitive.intersect(&ray, t_max)?;
         debug_assert!(si.t_hit <= 1.001 * t_max);
 
-        si.intr = self.render_from_primitive.apply(&si.intr);
+        si.intr = self.render_from_primitive.apply(si.intr);
         debug_assert!(si.intr.interaction.n.dot(si.intr.shading.n) >= 0.0);
 
         Some(si)
     }
 
     fn intersect_predicate(&self, ray: &Ray, mut t_max: Float) -> bool {
-        let ray = self.render_from_primitive.apply_ray(ray, Some(&mut t_max));
+        let ray = self.render_from_primitive.apply_ray(*ray, Some(&mut t_max));
         self.primitive.intersect_predicate(&ray, t_max)
     }
 }

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -12,6 +12,7 @@ pub trait RayI {
     fn get(&self, t: Float) -> Point3f;
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct Ray {
     /// Origin of the ray
     pub o: Point3f,
@@ -121,6 +122,8 @@ impl HasNan for Ray {
     }
 }
 
+
+#[derive(Debug, Copy, Clone)]
 pub struct RayDifferential {
     pub ray: Ray,
     pub auxiliary: Option<AuxiliaryRays>,
@@ -174,6 +177,7 @@ impl HasNan for RayDifferential {
 
 /// We wrap the differential information in a single struct so that
 /// we can guarantee all or none are present in RayDifferential via a single Option member.
+#[derive(Debug, Copy, Clone)]
 pub struct AuxiliaryRays {
     pub rx_origin: Point3f,
     pub rx_direction: Vector3f,

--- a/src/shape/bilinear_patch.rs
+++ b/src/shape/bilinear_patch.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use num::traits::int;
-
 use crate::bounding_box::Bounds3f;
 use crate::direction_cone::DirectionCone;
 use crate::float::gamma;
@@ -11,7 +9,7 @@ use crate::ray::Ray;
 use crate::sampling::{bilinear_pdf, invert_spherical_rectangle_sample, sample_bilinear, sample_spherical_rectangle};
 use crate::shape::ShapeSample;
 use crate::square_matrix::{Determinant, SquareMatrix};
-use crate::transform::Transform;
+use crate::transform::{Transform, TransformI};
 use crate::vecmath::normal::Normal3;
 use crate::vecmath::point::{Point3, Point3fi};
 use crate::vecmath::{invert_bilinear, spherical_quad_area, Length, Normal3f, Point2f, Point3f, Tuple2, Tuple3, Vector2f, Vector3f};
@@ -419,7 +417,7 @@ impl BilinearPatch{
                 dndv = dndt;
 
                 let r = Transform::rotate_from_to(&isect.interaction.n.into(), &ns.into());
-                isect.set_shading_geometry(ns, r.apply(&dpdu), r.apply(&dpdv), dndu, dndv, true);
+                isect.set_shading_geometry(ns, r.apply(dpdu), r.apply(dpdv), dndu, dndv, true);
             }
         }
 

--- a/src/shape/mesh.rs
+++ b/src/shape/mesh.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use ply_rs::{parser::Parser, ply};
 
 use crate::{
-    file, transform::Transform, vecmath::{Normal3f, Point2f, Point3f, Tuple2, Tuple3, Vector3f}
+    transform::{Transform, TransformI}, vecmath::{Normal3f, Point2f, Point3f, Tuple2, Tuple3, Vector3f}
 };
 
 #[derive(Debug, Clone)]
@@ -42,7 +42,7 @@ impl TriangleMesh {
         // Which is better depends on the specific intersection routine.
         let p = p
             .iter()
-            .map(|pt| render_from_object.apply(pt))
+            .map(|pt| render_from_object.apply(*pt))
             .collect_vec();
 
         if !uv.is_empty() {
@@ -53,7 +53,7 @@ impl TriangleMesh {
             debug_assert_eq!(n_vertices, n.len());
             n.iter()
                 .map(|nn| {
-                    let nn = render_from_object.apply(nn);
+                    let nn = render_from_object.apply(*nn);
                     if reverse_orientation {
                         -nn
                     } else {
@@ -68,7 +68,7 @@ impl TriangleMesh {
         let s = if !s.is_empty() {
             debug_assert_eq!(n_vertices, s.len());
             s.iter()
-                .map(|ss| render_from_object.apply(ss))
+                .map(|ss| render_from_object.apply(*ss))
                 .collect_vec()
         } else {
             s
@@ -131,7 +131,7 @@ impl BilinearPatchMesh{
         // Transform mesh vertices to rendering space
         let p = p
             .iter()
-            .map(|pt| render_from_object.apply(pt))
+            .map(|pt| render_from_object.apply(*pt))
             .collect_vec();
         
         // Copy UV and n vertex data, if present
@@ -146,7 +146,7 @@ impl BilinearPatchMesh{
             assert_eq!(n_vertices, n.len());
             for nn in n.iter_mut()
             {
-                *nn = render_from_object.apply(nn);
+                *nn = render_from_object.apply(*nn);
                 if reverse_orientation
                 {
                     *nn = -(*nn);

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -8,7 +8,7 @@ use crate::{
         sampled_wavelengths::SampledWavelengths,
         spectrum::{self, RgbAlbedoSpectrum, RgbIlluminantSpectrum, RgbUnboundedSpectrum, SpectrumI},
         Spectrum,
-    }, transform::Transform, vecmath::{normal::Normal3, spherical::spherical_theta, vector::Vector3, Normal3f, Normalize, Point2f, Point3f, Tuple2, Tuple3, Vector2f, Vector3f}, Float
+    }, transform::{Transform, TransformI}, vecmath::{normal::Normal3, spherical::spherical_theta, vector::Vector3, Normal3f, Normalize, Point2f, Point3f, Tuple2, Tuple3, Vector2f, Vector3f}, Float
 };
 
 pub trait FloatTextureI {
@@ -948,7 +948,7 @@ pub struct SphericalMapping
 
 impl TextureMapping2DI for SphericalMapping {
     fn map(&self, ctx: &TextureEvalContext) -> TexCoord2D {
-        let pt = self.texture_from_render.apply(&ctx.p);
+        let pt = self.texture_from_render.apply(ctx.p);
         let x2y2 = sqr(pt.x) + sqr(pt.y);
         let sqrtx2y2 = x2y2.sqrt();
         let dsdp = Vector3f::new(-pt.y, pt.x, 0.0) / (2.0 * PI_F * x2y2);
@@ -956,8 +956,8 @@ impl TextureMapping2DI for SphericalMapping {
             1.0 / (PI_F * (x2y2 + sqr(pt.z))) *
             Vector3f::new(pt.x * pt.z / sqrtx2y2, pt.y * pt.z / sqrtx2y2, -sqrtx2y2);
         
-        let dpdx = self.texture_from_render.apply(&ctx.dpdx);
-        let dpdy = self.texture_from_render.apply(&ctx.dpdy);
+        let dpdx = self.texture_from_render.apply(ctx.dpdx);
+        let dpdy = self.texture_from_render.apply(ctx.dpdy);
 
         let dsdx = dsdp.dot(dpdx);
         let dsdy = dsdp.dot(dpdy);
@@ -988,12 +988,12 @@ pub struct CylindricalMapping
 
 impl TextureMapping2DI for CylindricalMapping {
     fn map(&self, ctx: &TextureEvalContext) -> TexCoord2D {
-        let pt = self.texture_from_render.apply(&ctx.p);
+        let pt = self.texture_from_render.apply(ctx.p);
         let x2y2 = sqr(pt.x) + sqr(pt.y);
         let dsdp = Vector3f::new(-pt.y, pt.x, 0.0) / (2.0 * PI_F * x2y2);
         let dtdp = Vector3f::Z;
-        let dpdx = self.texture_from_render.apply(&ctx.dpdx);
-        let dpdy = self.texture_from_render.apply(&ctx.dpdy);
+        let dpdx = self.texture_from_render.apply(ctx.dpdx);
+        let dpdy = self.texture_from_render.apply(ctx.dpdy);
         let dsdx = dsdp.dot(dpdx);
         let dsdy = dsdp.dot(dpdy);
         let dtdx = dtdp.dot(dpdx);
@@ -1026,9 +1026,9 @@ pub struct PlanarMapping
 
 impl TextureMapping2DI for PlanarMapping {
     fn map(&self, ctx: &TextureEvalContext) -> TexCoord2D {
-        let vec: Vector3f = self.texture_from_render.apply(&ctx.p).into();
-        let dpdx = self.texture_from_render.apply(&ctx.dpdx);
-        let dpdy = self.texture_from_render.apply(&ctx.dpdy);
+        let vec: Vector3f = self.texture_from_render.apply(ctx.p).into();
+        let dpdx = self.texture_from_render.apply(ctx.dpdx);
+        let dpdy = self.texture_from_render.apply(ctx.dpdy);
         let dsdx = self.vs.dot(dpdx);
         let dsdy = self.vs.dot(dpdy);
         let dtdx = self.vt.dot(dpdx);


### PR DESCRIPTION
This is cleaner than implementing the trait on the type we want to transform.
Can instead implement Transform<T> for T.